### PR TITLE
Add Codex List Pagebuster script

### DIFF
--- a/index.json
+++ b/index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-05-24T15:13:44Z",
+  "updated_at": "2026-05-25T08:46:56Z",
   "scripts": [
     {
       "id": "codex-context-used-meter",
@@ -50,6 +50,23 @@
       "homepage": "https://github.com/kokotao/codex-token-usage-script",
       "script_url": "https://raw.githubusercontent.com/BigPizzaV3/CodexPlusPlusScriptMarket/main/scripts/codex-token-usage.js",
       "sha256": "a163bd62d886cd738adaa3966cfc92465892cea2cc9d4fd1dabecc4cc517fd2a"
+    },
+    {
+      "id": "codex-list-pagebuster",
+      "name": "Codex List Pagebuster",
+      "description": "补强 Codex Desktop 左侧原生会话列表，显示更多本地历史会话，并为无法进入原生列表的旧会话提供兜底入口。",
+      "version": "0.1.0",
+      "author": "puppnn",
+      "tags": [
+        "codex",
+        "history",
+        "sidebar",
+        "sessions",
+        "ui"
+      ],
+      "homepage": "https://github.com/puppnn/codex-plusplus-list-pagebuster",
+      "script_url": "https://raw.githubusercontent.com/BigPizzaV3/CodexPlusPlusScriptMarket/main/scripts/codex-list-pagebuster.js",
+      "sha256": "82b8da48c257ca3514b254c7fa469c79be641faf48093c68291529264bf2d7df"
     }
   ]
 }

--- a/index.json
+++ b/index.json
@@ -66,7 +66,7 @@
       ],
       "homepage": "https://github.com/puppnn/codex-plusplus-list-pagebuster",
       "script_url": "https://raw.githubusercontent.com/BigPizzaV3/CodexPlusPlusScriptMarket/main/scripts/codex-list-pagebuster.js",
-      "sha256": "39e42eb39a9d15c79e9b02e13cb0832cad18177992b52a7a8fc45c82568426ab"
+      "sha256": "7fb991273eda02538a22186d6c5891c4b67aff0d59491f3fde7cb396e2117e77"
     }
   ]
 }

--- a/index.json
+++ b/index.json
@@ -66,7 +66,7 @@
       ],
       "homepage": "https://github.com/puppnn/codex-plusplus-list-pagebuster",
       "script_url": "https://raw.githubusercontent.com/BigPizzaV3/CodexPlusPlusScriptMarket/main/scripts/codex-list-pagebuster.js",
-      "sha256": "82b8da48c257ca3514b254c7fa469c79be641faf48093c68291529264bf2d7df"
+      "sha256": "6338bfcd3666cf6709a2f0ad1a876b904f8c0ebdb2c5124f47967effacfaa831"
     }
   ]
 }

--- a/index.json
+++ b/index.json
@@ -66,7 +66,7 @@
       ],
       "homepage": "https://github.com/puppnn/codex-plusplus-list-pagebuster",
       "script_url": "https://raw.githubusercontent.com/BigPizzaV3/CodexPlusPlusScriptMarket/main/scripts/codex-list-pagebuster.js",
-      "sha256": "6338bfcd3666cf6709a2f0ad1a876b904f8c0ebdb2c5124f47967effacfaa831"
+      "sha256": "39e42eb39a9d15c79e9b02e13cb0832cad18177992b52a7a8fc45c82568426ab"
     }
   ]
 }

--- a/scripts/codex-list-pagebuster.js
+++ b/scripts/codex-list-pagebuster.js
@@ -1,0 +1,1076 @@
+(() => {
+  const TARGET = 500;
+  const SCRIPT_KEY = "__codexListPagebuster";
+  const STORAGE_KEY = "__codexListPagebusterThreads";
+  const PROJECT_LIST_SELECTOR = "[data-app-action-sidebar-project-list-id]";
+  const THREAD_SELECTOR = "[data-app-action-sidebar-thread-id]";
+  const SUPPLEMENT_SELECTOR = "[data-clpb-history-section]";
+  const MANAGED_ROW_SELECTOR = "[data-clpb-managed-row]";
+  const PROJECT_SUPPLEMENT_ITEM_SELECTOR = "[data-clpb-project-supplemental-item]";
+  const EXPAND_TEXT = /^(?:\u5c55\u5f00\u663e\u793a|\u663e\u793a\u66f4\u591a|Show more|Show all)$/i;
+  const KEYWORDS = /(?:thread|threads|session|sessions|history|recent|conversation|project)/i;
+  const LIMIT_KEYS = ["limit", "pageSize", "page_size", "first", "take", "perPage", "per_page", "count", "max", "size", "n"];
+  const ARCHIVED_IDS_KEY = "__codexListPagebusterArchivedIds";
+  const HIDDEN_IDS_KEY = "__codexListPagebusterHiddenIds";
+  const SIGNALS_MODULE_RE = /(?:\.\/)?assets\/app-server-manager-signals-[A-Za-z0-9_-]+\.js/g;
+  const SIGNALS_MODULE_FALLBACKS = [
+    "./assets/app-server-manager-signals-Csopz8aM.js",
+    "./assets/app-server-manager-signals-zAr_ejg8.js"
+  ];
+
+  if (window[SCRIPT_KEY]?.stop) {
+    window[SCRIPT_KEY].stop();
+  }
+
+  const state = {
+    observer: null,
+    timers: new Set(),
+    clicked: new WeakSet(),
+    scheduled: false,
+    autoExpandEnabled: true,
+    programmaticExpand: false,
+    projectClickListener: null,
+    autoExpandDeadlineMs: Date.now() + 8000,
+    lastProjectRoots: new Set(),
+    fetchPatched: false,
+    xhrPatched: false,
+    supplementIds: "",
+    promoteInFlight: false,
+    promotedKey: "",
+    internalActionModulePromise: null,
+    snapshotRefreshInFlight: false,
+    lastSnapshotRefreshAt: 0,
+    originalFetch: window.fetch,
+    originalXhrOpen: XMLHttpRequest.prototype.open,
+    originalXhrSend: XMLHttpRequest.prototype.send
+  };
+
+  function log(...args) {
+    try {
+      console.info("[clpb]", ...args);
+    } catch {}
+  }
+
+  function setManagedTimeout(fn, ms) {
+    const timer = window.setTimeout(() => {
+      state.timers.delete(timer);
+      fn();
+    }, ms);
+    state.timers.add(timer);
+  }
+
+  function rewriteUrl(raw) {
+    try {
+      const url = new URL(raw, window.location.href);
+      let changed = false;
+      for (const key of LIMIT_KEYS) {
+        if (!url.searchParams.has(key)) continue;
+        const value = Number.parseInt(url.searchParams.get(key) || "", 10);
+        if (Number.isFinite(value) && value > 0 && value <= 50) {
+          url.searchParams.set(key, String(TARGET));
+          changed = true;
+        }
+      }
+      return changed ? url.toString() : raw;
+    } catch {
+      return raw;
+    }
+  }
+
+  function rewriteBody(body) {
+    if (typeof body !== "string" || !body) return body;
+    let next = body;
+    for (const key of LIMIT_KEYS) {
+      const re = new RegExp(`(["']?${key}["']?\\s*[:=]\\s*)(\\d+)`, "gi");
+      next = next.replace(re, (match, prefix, value) => {
+        const n = Number.parseInt(value, 10);
+        return Number.isFinite(n) && n > 0 && n <= 50 ? `${prefix}${TARGET}` : match;
+      });
+    }
+    return next;
+  }
+
+  function patchRequests() {
+    if (!state.fetchPatched && typeof window.fetch === "function") {
+      const originalFetch = state.originalFetch.bind(window);
+      window.fetch = function patchedFetch(input, init) {
+        try {
+          const url = typeof input === "string" ? input : input?.url;
+          if (typeof url === "string" && KEYWORDS.test(url)) {
+            const next = rewriteUrl(url);
+            if (next !== url) log("fetch url", url, "->", next);
+            if (typeof input === "string") {
+              input = next;
+            } else if (input instanceof Request && next !== url) {
+              input = new Request(next, input);
+            }
+            if (init && typeof init.body === "string") {
+              const nextBody = rewriteBody(init.body);
+              if (nextBody !== init.body) log("fetch body patched");
+              init = { ...init, body: nextBody };
+            }
+          }
+        } catch (error) {
+          log("fetch patch error", String(error));
+        }
+        return originalFetch(input, init);
+      };
+      state.fetchPatched = true;
+    }
+
+    if (!state.xhrPatched) {
+      XMLHttpRequest.prototype.open = function patchedOpen(method, url, ...rest) {
+        const next = KEYWORDS.test(String(url)) ? rewriteUrl(String(url)) : url;
+        if (next !== url) log("xhr url", url, "->", next);
+        return state.originalXhrOpen.call(this, method, next, ...rest);
+      };
+      XMLHttpRequest.prototype.send = function patchedSend(body) {
+        try {
+          if (typeof body === "string") {
+            const nextBody = rewriteBody(body);
+            if (nextBody !== body) log("xhr body patched");
+            body = nextBody;
+          }
+        } catch (error) {
+          log("xhr patch error", String(error));
+        }
+        return state.originalXhrSend.call(this, body);
+      };
+      state.xhrPatched = true;
+    }
+  }
+
+  function isExpandButton(button) {
+    if (!(button instanceof HTMLButtonElement)) return false;
+    if (button.disabled || state.clicked.has(button)) return false;
+    return EXPAND_TEXT.test((button.textContent || "").trim());
+  }
+
+  function readSnapshotThreads() {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      const threads = raw ? JSON.parse(raw) : [];
+      const archivedIds = readArchivedIds();
+      const hiddenIds = readHiddenIds();
+      return Array.isArray(threads)
+        ? threads.filter((thread) => {
+            if (!thread || typeof thread.id !== "string") return false;
+            if (archivedIds.has(threadRawId(thread))) return false;
+            if (hiddenIds.has(threadRawId(thread))) return false;
+            const title = String(thread.title || "").trim();
+            const cwd = normalizeCwd(thread.cwd);
+            return Boolean(title || cwd);
+          })
+        : [];
+    } catch (error) {
+      log("snapshot read failed", String(error));
+      return [];
+    }
+  }
+
+  function readIdSet(key) {
+    try {
+      const raw = localStorage.getItem(key);
+      const ids = raw ? JSON.parse(raw) : [];
+      return new Set(Array.isArray(ids) ? ids.map(threadRawId).filter(Boolean) : []);
+    } catch {
+      return new Set();
+    }
+  }
+
+  function writeIdSet(key, ids, label) {
+    try {
+      localStorage.setItem(key, JSON.stringify(Array.from(ids)));
+    } catch (error) {
+      log(`${label} ids write failed`, String(error));
+    }
+  }
+
+  function readArchivedIds() {
+    return readIdSet(ARCHIVED_IDS_KEY);
+  }
+
+  function writeArchivedIds(ids) {
+    writeIdSet(ARCHIVED_IDS_KEY, ids, "archived");
+  }
+
+  function readHiddenIds() {
+    return readIdSet(HIDDEN_IDS_KEY);
+  }
+
+  function writeHiddenIds(ids) {
+    writeIdSet(HIDDEN_IDS_KEY, ids, "hidden");
+  }
+
+  function threadRawId(threadOrId) {
+    const id = typeof threadOrId === "string" ? threadOrId : threadOrId?.id;
+    return String(id || "").replace(/^local:/, "");
+  }
+
+  function threadDomId(threadOrId) {
+    return `local:${threadRawId(threadOrId)}`;
+  }
+
+  function normalizeCwd(cwd) {
+    return String(cwd || "")
+      .replace(/^\\\\\?\\/, "")
+      .replace(/\s+/g, " ")
+      .trim();
+  }
+
+  function normalizePathForCompare(path) {
+    return normalizeCwd(path)
+      .replace(/[\\/]+$/g, "")
+      .toLowerCase();
+  }
+
+  function basename(path) {
+    const normalized = normalizeCwd(path);
+    return normalized.split(/[\\/]/).filter(Boolean).pop() || normalized || "unknown";
+  }
+
+  function rememberProjectRoots(roots) {
+    const next = new Set(state.lastProjectRoots);
+    for (const root of roots) {
+      if (root) next.add(root);
+    }
+    state.lastProjectRoots = next;
+    return next;
+  }
+
+  function collectSnapshotProjectRoots() {
+    return new Set(
+      readSnapshotThreads()
+        .map((thread) => normalizePathForCompare(thread.cwd))
+        .filter(Boolean)
+    );
+  }
+
+  function writeSnapshotThreads(threads) {
+    try {
+      const archivedIds = readArchivedIds();
+      const hiddenIds = readHiddenIds();
+      const activeThreads = threads.filter((thread) => {
+        const rawId = threadRawId(thread);
+        return !archivedIds.has(rawId) && !hiddenIds.has(rawId);
+      });
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(activeThreads));
+    } catch (error) {
+      log("snapshot write failed", String(error));
+    }
+  }
+
+  function pruneSnapshotThreads(idsToRemove) {
+    const removeSet = new Set(Array.from(idsToRemove).map(threadRawId).filter(Boolean));
+    if (removeSet.size === 0) return 0;
+    const threads = readSnapshotThreads();
+    const next = threads.filter((thread) => !removeSet.has(threadRawId(thread)));
+    if (next.length === threads.length) return 0;
+    writeSnapshotThreads(next);
+    state.supplementIds = "";
+    return threads.length - next.length;
+  }
+
+  function rememberArchivedIds(ids) {
+    const archivedIds = readArchivedIds();
+    let changed = false;
+    for (const id of ids) {
+      const rawId = threadRawId(id);
+      if (!rawId || archivedIds.has(rawId)) continue;
+      archivedIds.add(rawId);
+      changed = true;
+    }
+    if (changed) writeArchivedIds(archivedIds);
+    return archivedIds;
+  }
+
+  function rememberHiddenIds(ids) {
+    const hiddenIds = readHiddenIds();
+    let changed = false;
+    for (const id of ids) {
+      const rawId = threadRawId(id);
+      if (!rawId || hiddenIds.has(rawId)) continue;
+      hiddenIds.add(rawId);
+      changed = true;
+    }
+    if (changed) writeHiddenIds(hiddenIds);
+    return hiddenIds;
+  }
+
+  function collectVisibleProjectRoots() {
+    const roots = new Set(
+      Array.from(document.querySelectorAll("[data-app-action-sidebar-project-id]"))
+        .map((row) => row.getAttribute("data-app-action-sidebar-project-id"))
+        .map(normalizePathForCompare)
+        .filter(Boolean)
+    );
+    if (roots.size > 0) {
+      return rememberProjectRoots(roots);
+    }
+    if (state.lastProjectRoots.size > 0) {
+      return state.lastProjectRoots;
+    }
+    const snapshotRoots = collectSnapshotProjectRoots();
+    if (snapshotRoots.size > 0 && document.querySelector(PROJECT_LIST_SELECTOR)) {
+      return rememberProjectRoots(snapshotRoots);
+    }
+    return snapshotRoots;
+  }
+
+  function threadHasVisibleProject(thread, projectRoots) {
+    const cwd = normalizePathForCompare(thread?.cwd);
+    if (!cwd) return false;
+    for (const root of projectRoots) {
+      if (!root) continue;
+      if (cwd === root || cwd.startsWith(`${root}/`) || cwd.startsWith(`${root}\\`)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  function collectNativeThreadIds() {
+    return new Set(
+      Array.from(document.querySelectorAll(THREAD_SELECTOR))
+        .filter((row) => !row.closest(SUPPLEMENT_SELECTOR) && !row.closest(MANAGED_ROW_SELECTOR))
+        .map((row) => row.getAttribute("data-app-action-sidebar-thread-id"))
+        .filter(Boolean)
+    );
+  }
+
+  function callAppAction(action, timeoutMs = 12000) {
+    return new Promise((resolve, reject) => {
+      const requestId = `clpb-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      const timeout = window.setTimeout(() => {
+        window.removeEventListener("message", onMessage);
+        reject(new Error(`Codex app action timed out: ${action.type}`));
+      }, timeoutMs);
+
+      function onMessage(event) {
+        const data = event.data;
+        if (!data || data.type !== "debug-run-app-action-response" || data.requestId !== requestId) return;
+        window.clearTimeout(timeout);
+        window.removeEventListener("message", onMessage);
+        if (data.ok) {
+          resolve(data.result);
+        } else {
+          reject(new Error(data.errorMessage || `Codex app action failed: ${action.type}`));
+        }
+      }
+
+      window.addEventListener("message", onMessage);
+      const message = { type: "debug-run-app-action-request", requestId, action };
+      const bridge = window.electronBridge;
+      if (bridge?.sendMessageFromView) {
+        bridge.sendMessageFromView(message).catch((error) => {
+          window.clearTimeout(timeout);
+          window.removeEventListener("message", onMessage);
+          reject(error);
+        });
+      } else {
+        window.postMessage(message, "*");
+      }
+    });
+  }
+
+  async function callInternalAction(type, payload) {
+    const sendRequest = await loadInternalActionModule();
+    return sendRequest(type, payload);
+  }
+
+  function findInternalRequestHelper(mod) {
+    const preferred = ["ts", "It", "ln"];
+    for (const key of preferred) {
+      const value = mod?.[key];
+      if (typeof value !== "function") continue;
+      const source = Function.prototype.toString.call(value);
+      if (/sendRequest\s*\(/.test(source)) return { key, fn: value };
+    }
+
+    for (const key of Object.keys(mod || {})) {
+      const value = mod[key];
+      if (typeof value !== "function") continue;
+      let source = "";
+      try {
+        source = Function.prototype.toString.call(value);
+      } catch {
+        continue;
+      }
+      if (/sendRequest\s*\(/.test(source)) return { key, fn: value };
+    }
+    return null;
+  }
+
+  function normalizeSignalsModulePath(path) {
+    if (!path) return "";
+    if (/^https?:|^app:|^file:/i.test(path)) return path;
+    const relative = path.replace(/^\.\//, "");
+    return relative.startsWith("assets/") ? `./${relative}` : "";
+  }
+
+  function collectSignalsModuleCandidatesFromText(text) {
+    const candidates = [];
+    if (typeof text !== "string" || !text) return candidates;
+    for (const match of text.matchAll(SIGNALS_MODULE_RE)) {
+      const candidate = normalizeSignalsModulePath(match[0]);
+      if (candidate) candidates.push(candidate);
+    }
+    return candidates;
+  }
+
+  function collectSignalsModuleCandidatesFromRuntime() {
+    const candidates = new Set(SIGNALS_MODULE_FALLBACKS);
+    const add = (value) => {
+      const candidate = normalizeSignalsModulePath(value);
+      if (candidate) candidates.add(candidate);
+    };
+
+    collectSignalsModuleCandidatesFromText(document.documentElement?.outerHTML || "").forEach(add);
+
+    for (const script of document.querySelectorAll("script[src]")) {
+      add(script.getAttribute("src") || "");
+    }
+
+    try {
+      for (const entry of performance.getEntriesByType("resource")) {
+        const name = String(entry.name || "");
+        if (name.includes("app-server-manager-signals-")) add(name);
+      }
+    } catch {}
+
+    return Array.from(candidates);
+  }
+
+  async function discoverSignalsModuleCandidates() {
+    const candidates = new Set(collectSignalsModuleCandidatesFromRuntime());
+    const scriptsToScan = new Set(
+      Array.from(document.querySelectorAll("script[src]"))
+        .map((script) => script.getAttribute("src"))
+        .filter(Boolean)
+    );
+
+    try {
+      for (const entry of performance.getEntriesByType("resource")) {
+        const name = String(entry.name || "");
+        if (/\.js(?:$|\?)/.test(name)) scriptsToScan.add(name);
+      }
+    } catch {}
+
+    for (const scriptUrl of scriptsToScan) {
+      try {
+        const response = await fetch(scriptUrl);
+        if (!response.ok) continue;
+        collectSignalsModuleCandidatesFromText(await response.text()).forEach((candidate) => {
+          candidates.add(candidate);
+        });
+      } catch {}
+    }
+
+    return Array.from(candidates);
+  }
+
+  async function loadInternalActionModule() {
+    if (!state.internalActionModulePromise) {
+      state.internalActionModulePromise = (async () => {
+        const candidates = await discoverSignalsModuleCandidates();
+        let lastError = null;
+        for (const candidate of candidates) {
+          try {
+            const mod = await import(candidate);
+            const helper = findInternalRequestHelper(mod);
+            if (helper) {
+              log("internal action module", candidate, helper.key);
+              return helper.fn;
+            }
+          } catch (error) {
+            lastError = error;
+          }
+        }
+        throw lastError || new Error("Codex internal request helper module was not found");
+      })().catch((error) => {
+        state.internalActionModulePromise = null;
+        throw error;
+      });
+    }
+    return state.internalActionModulePromise;
+  }
+
+  function sourceLooksInternal(source) {
+    if (source == null) return false;
+    if (typeof source === "string") {
+      return /(?:guardian|subagent|background|approval|review)/i.test(source);
+    }
+    if (typeof source !== "object") return false;
+    if (source.subagent != null) return true;
+    if (source.parentThreadId != null) return true;
+    if (source.sourceThreadId != null) return true;
+    try {
+      return /(?:guardian|subagent|background|approval|review)/i.test(JSON.stringify(source));
+    } catch {
+      return false;
+    }
+  }
+
+  function shouldHideThread(thread) {
+    if (!thread || typeof thread !== "object") return false;
+    if (
+      thread.archived === true ||
+      thread.archived === 1 ||
+      thread.archived === "true" ||
+      thread.status === "archived" ||
+      thread.status?.type === "archived"
+    ) {
+      return true;
+    }
+    const knownPath = String(thread.path || thread.rolloutPath || thread.savedPath || "").replaceAll("\\", "/");
+    if (/\/archived_sessions\//i.test(knownPath)) return true;
+    if (sourceLooksInternal(thread.source)) return true;
+    if (sourceLooksInternal(thread.threadSource)) return true;
+    if (sourceLooksInternal(thread.originator)) return true;
+    if (typeof thread.agentRole === "string" && /(?:guardian|subagent|background|approval|review)/i.test(thread.agentRole)) return true;
+    if (typeof thread.agentNickname === "string" && /(?:guardian|subagent|background|approval|review)/i.test(thread.agentNickname)) return true;
+    return false;
+  }
+
+  function normalizeListedThread(thread) {
+    if (!thread || typeof thread.id !== "string") return null;
+    if (shouldHideThread(thread)) return null;
+    const cwd = normalizeCwd(thread.cwd);
+    const title = String(thread.name || thread.title || thread.preview || "").trim();
+    if (!cwd && !title) return null;
+    return {
+      id: threadRawId(thread.id),
+      title: title || thread.id,
+      cwd
+    };
+  }
+
+  function mergeSnapshotThreads(nextThreads) {
+    const archivedIds = readArchivedIds();
+    const hiddenIds = readHiddenIds();
+    const byId = new Map();
+    for (const thread of readSnapshotThreads()) {
+      const rawId = threadRawId(thread);
+      if (!archivedIds.has(rawId) && !hiddenIds.has(rawId)) byId.set(rawId, thread);
+    }
+    for (const thread of nextThreads) {
+      const normalized = normalizeListedThread(thread);
+      if (!normalized) continue;
+      const rawId = threadRawId(normalized);
+      if (archivedIds.has(rawId) || hiddenIds.has(rawId)) continue;
+      const existing = byId.get(normalized.id);
+      byId.set(normalized.id, {
+        ...existing,
+        ...normalized
+      });
+    }
+    const merged = Array.from(byId.values()).filter((thread) => threadRawId(thread));
+    writeSnapshotThreads(merged);
+    return merged.length;
+  }
+
+  async function sendCliRequest(method, params, options = {}) {
+    return callInternalAction("send-cli-request-for-host", {
+      hostId: "local",
+      method,
+      params,
+      timeoutMs: options.timeoutMs
+    });
+  }
+
+  async function listThreadsFromCli({ archived, limit = TARGET }) {
+    const threads = [];
+    let cursor = null;
+    for (let page = 0; page < 20 && threads.length < limit; page += 1) {
+      const result = await sendCliRequest(
+        "thread/list",
+        {
+          archived,
+          cursor,
+          limit: 50,
+          modelProviders: null,
+          sortKey: "updated_at"
+        },
+        { timeoutMs: 12000 }
+      );
+      const data = Array.isArray(result?.data) ? result.data : [];
+      threads.push(...data);
+      cursor = result?.nextCursor || null;
+      if (!cursor || data.length === 0) break;
+    }
+    return threads;
+  }
+
+  async function refreshSnapshotFromCli(force = false) {
+    const now = Date.now();
+    if (state.snapshotRefreshInFlight) return;
+    if (!force && now - state.lastSnapshotRefreshAt < 30000) return;
+    state.snapshotRefreshInFlight = true;
+    state.lastSnapshotRefreshAt = now;
+    try {
+      const [threads, archivedThreads] = await Promise.all([
+        listThreadsFromCli({ archived: false }),
+        listThreadsFromCli({ archived: true })
+      ]);
+      const archivedIds = rememberArchivedIds(archivedThreads.map(threadRawId));
+      const hiddenIds = rememberHiddenIds(threads.filter(shouldHideThread).map(threadRawId));
+      const idsToRemove = new Set([...archivedIds, ...hiddenIds]);
+      const removedArchived = pruneSnapshotThreads(idsToRemove);
+      const count = mergeSnapshotThreads(threads);
+      log("snapshot refreshed", {
+        fetched: threads.length,
+        archived: archivedThreads.length,
+        hidden: hiddenIds.size,
+        removedArchived,
+        snapshot: count
+      });
+      state.supplementIds = "";
+      scheduleExpand("snapshot-refresh");
+    } catch (error) {
+      log("snapshot refresh failed", String(error));
+    } finally {
+      state.snapshotRefreshInFlight = false;
+    }
+  }
+
+  async function loadThreadIntoNativeCache(rawId) {
+    await callInternalAction("load-recent-conversation-ids-for-host", {
+      hostId: "local",
+      conversationIds: [rawId]
+    });
+    const result = await sendCliRequest(
+      "thread/read",
+      {
+        threadId: rawId,
+        includeTurns: false
+      },
+      { timeoutMs: 12000 }
+    ).catch(() => null);
+    const rawThread = result?.thread || result;
+    if (rawThread?.archived === true || rawThread?.status?.type === "archived") {
+      rememberArchivedIds([rawId]);
+      pruneSnapshotThreads([rawId]);
+      return false;
+    }
+    if (shouldHideThread(rawThread)) {
+      rememberHiddenIds([rawId]);
+      pruneSnapshotThreads([rawId]);
+      return false;
+    }
+    const thread = normalizeListedThread(rawThread);
+    if (thread) mergeSnapshotThreads([thread]);
+    return true;
+  }
+
+  async function promoteMissingToNative(missing) {
+    const ids = Array.from(new Set(missing.map(threadRawId).filter(Boolean)));
+    if (ids.length === 0 || state.promoteInFlight) return;
+    const key = ids.join("|");
+    if (key === state.promotedKey) return;
+    state.promoteInFlight = true;
+    state.promotedKey = key;
+    try {
+      const results = await Promise.all(
+        ids.map(async (id) => {
+          try {
+            return (await loadThreadIntoNativeCache(id)) ? id : null;
+          } catch {
+            return null;
+          }
+        })
+      );
+      const foundSet = new Set(results.filter(Boolean));
+      const staleIds = ids.filter((id) => !foundSet.has(id));
+      if (staleIds.length > 0) {
+        const removed = pruneSnapshotThreads(staleIds);
+        if (removed > 0) {
+          log("stale snapshot pruned", {
+            removed,
+            stale: staleIds.length
+          });
+        }
+      }
+      log("thread metadata check", {
+        requested: ids.length,
+        found: foundSet.size
+      });
+      setManagedTimeout(() => scheduleExpand("metadata-check"), 250);
+    } catch (error) {
+      state.promotedKey = "";
+      log("thread metadata check failed", String(error));
+    } finally {
+      state.promoteInFlight = false;
+    }
+  }
+
+  function findNativeThreadRow(localId) {
+    return Array.from(document.querySelectorAll(`[data-app-action-sidebar-thread-id="${CSS.escape(localId)}"]`))
+      .find((row) => row instanceof HTMLElement && !row.hasAttribute("data-clpb-managed-row") && !row.closest(SUPPLEMENT_SELECTOR));
+  }
+
+  function getReactPropsKey(element) {
+    return Object.keys(element).find((key) => key.startsWith("__reactProps"));
+  }
+
+  function clickNativeThreadRow(localId) {
+    const row = findNativeThreadRow(localId);
+    if (!row) return false;
+
+    const reactPropsKey = getReactPropsKey(row);
+    const onClick = reactPropsKey ? row[reactPropsKey]?.onClick : null;
+    if (typeof onClick === "function") {
+      const event = {
+        currentTarget: row,
+        target: row,
+        defaultPrevented: false,
+        preventDefault() {
+          this.defaultPrevented = true;
+        },
+        stopPropagation() {
+          this.propagationStopped = true;
+        }
+      };
+      onClick(event);
+      return true;
+    }
+
+    row.click();
+    return true;
+  }
+
+  async function waitForNativeThreadRow(localId, timeoutMs = 5000) {
+    const startedAt = Date.now();
+    while (Date.now() - startedAt < timeoutMs) {
+      if (findNativeThreadRow(localId)) return true;
+      await new Promise((resolve) => setTimeout(resolve, 150));
+    }
+    return false;
+  }
+
+  async function openThread(thread) {
+    const rawId = threadRawId(thread);
+    const localId = `local:${rawId}`;
+    const cwd = normalizeCwd(thread.cwd) || "/";
+
+    try {
+      const found = await loadThreadIntoNativeCache(rawId);
+      log("native cache load", rawId, found);
+    } catch (error) {
+      log("native cache load failed", rawId, String(error));
+    }
+
+    try {
+      const cwd = normalizeCwd(thread.cwd) || "/";
+      await callInternalAction("maybe-resume-conversation", {
+        hostId: "local",
+        conversationId: rawId,
+        model: null,
+        serviceTier: null,
+        reasoningEffort: null,
+        workspaceRoots: [cwd],
+        permissions: null,
+        collaborationMode: null,
+        showThreadGoalResumeConfirmation: true,
+        showPausedGoalResumeConfirmation: true
+      });
+      log("thread resumed", rawId);
+    } catch (error) {
+      log("thread resume failed", rawId, String(error));
+    }
+
+    try {
+      await loadThreadIntoNativeCache(rawId);
+    } catch (error) {
+      log("native cache reload failed", rawId, String(error));
+    }
+
+    scheduleExpand("open-thread");
+
+    if (await waitForNativeThreadRow(localId)) {
+      if (clickNativeThreadRow(localId)) {
+        log("native row clicked", rawId);
+        return;
+      }
+    }
+
+    try {
+      await callAppAction({
+        type: "windows.show_thread",
+        windowId: "current",
+        threadId: rawId
+      });
+      return;
+    } catch (error) {
+      log("show thread raw failed", rawId, String(error));
+    }
+
+    try {
+      await callAppAction({
+        type: "windows.show_thread",
+        windowId: "current",
+        threadId: localId
+      });
+    } catch (error) {
+      log("show thread local failed", localId, String(error));
+    }
+  }
+
+  function makeSupplementalRow(thread, options = {}) {
+    const threadId = threadDomId(thread);
+    const titleText = thread.title || "Untitled thread";
+
+    const item = document.createElement("div");
+    item.className = "after:block after:h-px after:content-[''] last:after:hidden";
+    item.setAttribute("role", "listitem");
+    item.setAttribute("data-clpb-supplemental-item", "");
+    if (options.project) item.setAttribute("data-clpb-project-supplemental-item", "");
+
+    const row = document.createElement("div");
+    row.className = "group relative min-h-token-nav-row cursor-interaction rounded-lg px-row-x py-row-y text-sm hover:bg-token-list-hover-background focus-visible:outline-offset-[-2px]";
+    row.setAttribute("data-app-action-sidebar-thread-host-id", "local");
+    row.setAttribute("data-app-action-sidebar-thread-id", threadId);
+    row.setAttribute("data-app-action-sidebar-thread-kind", "local");
+    row.setAttribute("data-app-action-sidebar-thread-pinned", "false");
+    row.setAttribute("data-app-action-sidebar-thread-row", "");
+    row.setAttribute("data-app-action-sidebar-thread-title", titleText);
+    row.setAttribute("data-clpb-supplemental-row", "true");
+    row.setAttribute("data-clpb-managed-row", "true");
+    row.setAttribute("role", "button");
+    row.setAttribute("tabindex", "0");
+    row.setAttribute("data-state", "closed");
+    row.title = `${titleText}\n${normalizeCwd(thread.cwd)}`;
+
+    const title = document.createElement("div");
+    title.className = "min-w-0 truncate text-token-text-primary";
+    title.textContent = titleText;
+
+    const project = document.createElement("div");
+    project.className = "min-w-0 truncate text-xs text-token-text-tertiary";
+    project.textContent = basename(thread.cwd);
+
+    row.append(title, project);
+    row.addEventListener("click", (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      openThread(thread);
+    });
+    row.addEventListener("keydown", (event) => {
+      if (event.key !== "Enter" && event.key !== " ") return;
+      event.preventDefault();
+      event.stopPropagation();
+      openThread(thread);
+    });
+
+    item.appendChild(row);
+    return item;
+  }
+
+  function getProjectThreadList(projectList) {
+    return projectList.querySelector('[role="list"]') || projectList.querySelector(".flex.flex-col") || projectList;
+  }
+
+  function projectHasCollapsedThreads(projectList) {
+    return Array.from(projectList.querySelectorAll("button")).some(isExpandButton);
+  }
+
+  function renderProjectSupplementalHistory(threads, nativeIds) {
+    document.querySelectorAll(PROJECT_SUPPLEMENT_ITEM_SELECTOR).forEach((item) => item.remove());
+
+    let rendered = 0;
+    const seen = new Set();
+    for (const projectList of document.querySelectorAll(PROJECT_LIST_SELECTOR)) {
+      const root = normalizePathForCompare(projectList.getAttribute("data-app-action-sidebar-project-list-id"));
+      if (!root) continue;
+      if (projectHasCollapsedThreads(projectList)) continue;
+      const list = getProjectThreadList(projectList);
+      const matches = threads.filter((thread) => {
+        const id = threadDomId(thread);
+        if (nativeIds.has(id) || seen.has(id)) return false;
+        return threadHasVisibleProject(thread, new Set([root]));
+      });
+      for (const thread of matches) {
+        seen.add(threadDomId(thread));
+        list.appendChild(makeSupplementalRow(thread, { project: true }));
+        rendered += 1;
+      }
+    }
+
+    if (rendered > 0) {
+      log("project supplement rendered", { rendered });
+    }
+    return seen;
+  }
+
+  function countExpandButtons() {
+    return Array.from(document.querySelectorAll(`${PROJECT_LIST_SELECTOR} button`)).filter(isExpandButton).length;
+  }
+
+  function renderSupplementalHistory() {
+    const scroll = document.querySelector("[data-app-action-sidebar-scroll]");
+    if (!scroll) return;
+
+    const threads = readSnapshotThreads();
+    const nativeIds = collectNativeThreadIds();
+    const projectRoots = collectVisibleProjectRoots();
+    const missingNative = threads.filter((thread) => !nativeIds.has(threadDomId(thread)));
+    const projectSupplementIds = renderProjectSupplementalHistory(missingNative, nativeIds);
+    const missing = missingNative.filter((thread) => {
+      if (projectSupplementIds.has(threadDomId(thread))) return false;
+      return !threadHasVisibleProject(thread, projectRoots);
+    });
+    const nextIds = missing.map((thread) => threadDomId(thread)).join("|");
+    const existing = document.querySelector(SUPPLEMENT_SELECTOR);
+
+    promoteMissingToNative(missingNative);
+
+    if (missing.length === 0) {
+      existing?.remove();
+      state.supplementIds = "";
+      return;
+    }
+    if (existing && state.supplementIds === nextIds) return;
+
+    existing?.remove();
+    state.supplementIds = nextIds;
+
+    const section = document.createElement("div");
+    section.className = "px-row-x";
+    section.setAttribute("data-app-action-sidebar-section", "");
+    section.setAttribute("data-clpb-history-section", "");
+
+    const heading = document.createElement("div");
+    heading.className = "flex h-8 items-center px-2 text-xs font-semibold uppercase text-token-text-tertiary";
+    heading.textContent = `Extra history (${missing.length})`;
+
+    const list = document.createElement("div");
+    list.className = "flex flex-col gap-px";
+    list.setAttribute("role", "list");
+    list.setAttribute("aria-label", "Extra history");
+    missing.forEach((thread) => list.appendChild(makeSupplementalRow(thread)));
+
+    section.append(heading, list);
+    scroll.appendChild(section);
+    log("supplement rendered", {
+      missing: missing.length,
+      snapshot: threads.length,
+      native: nativeIds.size
+    });
+  }
+
+  function expandNativeProjectLists(reason = "scan") {
+    let clicked = 0;
+    const lists = Array.from(document.querySelectorAll(PROJECT_LIST_SELECTOR));
+    state.programmaticExpand = true;
+    try {
+      for (const list of lists) {
+        const buttons = Array.from(list.querySelectorAll("button")).filter(isExpandButton);
+        for (const button of buttons) {
+          state.clicked.add(button);
+          button.click();
+          clicked += 1;
+        }
+      }
+    } finally {
+      state.programmaticExpand = false;
+    }
+    if (clicked || reason === "manual") {
+      log("native expand", {
+        reason,
+        clicked,
+        projects: lists.length,
+        threads: document.querySelectorAll(THREAD_SELECTOR).length,
+        remainingExpandButtons: countExpandButtons()
+      });
+    }
+    renderSupplementalHistory();
+    return clicked;
+  }
+
+  function autoExpandNativeProjectLists(reason) {
+    const withinAutoWindow = Date.now() <= state.autoExpandDeadlineMs;
+    if (!state.autoExpandEnabled || !withinAutoWindow) {
+      renderSupplementalHistory();
+      return 0;
+    }
+    return expandNativeProjectLists(reason);
+  }
+
+  function scheduleExpand(reason) {
+    if (state.scheduled) return;
+    state.scheduled = true;
+    requestAnimationFrame(() => {
+      state.scheduled = false;
+      if (reason !== "manual") {
+        const withinAutoWindow = Date.now() <= state.autoExpandDeadlineMs;
+        if (state.autoExpandEnabled && withinAutoWindow) {
+          autoExpandNativeProjectLists(reason);
+          return;
+        }
+      }
+      renderSupplementalHistory();
+    });
+  }
+
+  function installObserver() {
+    state.projectClickListener = (event) => {
+      if (state.programmaticExpand) return;
+      const target = event.target;
+      const button = target instanceof Element ? target.closest(`${PROJECT_LIST_SELECTOR} button`) : null;
+      if (button) {
+        state.autoExpandEnabled = false;
+      }
+    };
+    document.addEventListener(
+      "click",
+      state.projectClickListener,
+      true
+    );
+
+    state.observer = new MutationObserver(() => scheduleExpand("mutation"));
+    state.observer.observe(document.documentElement, {
+      childList: true,
+      subtree: true
+    });
+  }
+
+  function stop() {
+    if (state.observer) state.observer.disconnect();
+    if (state.projectClickListener) {
+      document.removeEventListener("click", state.projectClickListener, true);
+    }
+    for (const timer of state.timers) window.clearTimeout(timer);
+    state.timers.clear();
+    if (state.fetchPatched) window.fetch = state.originalFetch;
+    if (state.xhrPatched) {
+      XMLHttpRequest.prototype.open = state.originalXhrOpen;
+      XMLHttpRequest.prototype.send = state.originalXhrSend;
+    }
+    log("stopped");
+  }
+
+  window[SCRIPT_KEY] = {
+    expand: () => expandNativeProjectLists("manual"),
+    open: openThread,
+    status: () => ({
+      projects: document.querySelectorAll(PROJECT_LIST_SELECTOR).length,
+      threads: document.querySelectorAll(THREAD_SELECTOR).length,
+      nativeThreads: collectNativeThreadIds().size,
+      supplementThreads: document.querySelectorAll("[data-clpb-supplemental-row]").length,
+      snapshotThreads: readSnapshotThreads().length,
+      missingNativeThreads: readSnapshotThreads().filter((thread) => !collectNativeThreadIds().has(threadDomId(thread))).length,
+      expandButtons: countExpandButtons(),
+      href: location.href
+    }),
+    stop
+  };
+
+  patchRequests();
+  installObserver();
+  log("loaded", window[SCRIPT_KEY].status());
+  refreshSnapshotFromCli();
+  scheduleExpand("load");
+  renderSupplementalHistory();
+  [250, 750, 1500, 3000].forEach((ms) => {
+    setManagedTimeout(() => autoExpandNativeProjectLists(`timer:${ms}`), ms);
+  });
+})();

--- a/scripts/codex-list-pagebuster.js
+++ b/scripts/codex-list-pagebuster.js
@@ -921,17 +921,36 @@
   function renderProjectSupplementalHistory(threads, nativeIds) {
     document.querySelectorAll(PROJECT_SUPPLEMENT_ITEM_SELECTOR).forEach((item) => item.remove());
 
+    const sidebarProjectIds = new Set();
+    for (const row of document.querySelectorAll("[data-app-action-sidebar-project-id]")) {
+      const value = normalizePathForCompare(row.getAttribute("data-app-action-sidebar-project-id"));
+      if (value) sidebarProjectIds.add(value);
+    }
+
     let rendered = 0;
     const seen = new Set();
     for (const projectList of document.querySelectorAll(PROJECT_LIST_SELECTOR)) {
       const root = normalizePathForCompare(projectList.getAttribute("data-app-action-sidebar-project-list-id"));
       if (!root) continue;
       if (projectHasCollapsedThreads(projectList)) continue;
+
+      const nestedProjects = [];
+      for (const pid of sidebarProjectIds) {
+        if (pid !== root && pid.startsWith(`${root}/`)) {
+          nestedProjects.push(pid);
+        }
+      }
+
       const list = getProjectThreadList(projectList);
       const matches = threads.filter((thread) => {
         const id = threadDomId(thread);
         if (nativeIds.has(id) || seen.has(id)) return false;
-        return threadHasVisibleProject(thread, new Set([root]));
+        if (!threadHasVisibleProject(thread, new Set([root]))) return false;
+        const cwd = normalizePathForCompare(thread?.cwd);
+        for (const nested of nestedProjects) {
+          if (cwd === nested || cwd.startsWith(`${nested}/`)) return false;
+        }
+        return true;
       });
       for (const thread of matches) {
         seen.add(threadDomId(thread));

--- a/scripts/codex-list-pagebuster.js
+++ b/scripts/codex-list-pagebuster.js
@@ -221,6 +221,7 @@
   function normalizePathForCompare(path) {
     return normalizeCwd(path)
       .replace(/[\\/]+$/g, "")
+      .replaceAll("\\", "/")
       .toLowerCase();
   }
 
@@ -297,6 +298,23 @@
     return hiddenIds;
   }
 
+  function collectSidebarProjectBasenames() {
+    const basenames = new Set();
+    const add = (value) => {
+      const normalized = normalizePathForCompare(value);
+      if (!normalized) return;
+      const base = normalized.split("/").filter(Boolean).pop() || normalized;
+      if (base) basenames.add(base);
+    };
+    for (const row of document.querySelectorAll("[data-app-action-sidebar-project-id]")) {
+      add(row.getAttribute("data-app-action-sidebar-project-id"));
+    }
+    for (const projectList of document.querySelectorAll(PROJECT_LIST_SELECTOR)) {
+      add(projectList.getAttribute("data-app-action-sidebar-project-list-id"));
+    }
+    return basenames;
+  }
+
   function collectVisibleProjectRoots() {
     const roots = new Set();
     const addRoot = (value) => {
@@ -304,11 +322,31 @@
       if (root) roots.add(root);
     };
 
-    for (const row of document.querySelectorAll("[data-app-action-sidebar-project-id]")) {
-      addRoot(row.getAttribute("data-app-action-sidebar-project-id"));
-    }
     for (const projectList of document.querySelectorAll(PROJECT_LIST_SELECTOR)) {
       addRoot(projectList.getAttribute("data-app-action-sidebar-project-list-id"));
+    }
+
+    const projectIdValues = [];
+    for (const row of document.querySelectorAll("[data-app-action-sidebar-project-id]")) {
+      const value = row.getAttribute("data-app-action-sidebar-project-id");
+      const normalized = normalizePathForCompare(value);
+      if (normalized) {
+        addRoot(normalized);
+        projectIdValues.push(normalized);
+      }
+    }
+
+    const shortNames = projectIdValues.filter((id) => !/[/:]/.test(id));
+    if (shortNames.length > 0) {
+      const shortNameSet = new Set(shortNames);
+      for (const thread of readSnapshotThreads()) {
+        const cwd = normalizePathForCompare(thread.cwd);
+        if (!cwd) continue;
+        const base = cwd.split("/").filter(Boolean).pop() || "";
+        if (base && shortNameSet.has(base)) {
+          addRoot(cwd);
+        }
+      }
     }
 
     if (roots.size > 0) {
@@ -921,9 +959,15 @@
     const projectRoots = collectVisibleProjectRoots();
     const missingNative = threads.filter((thread) => !nativeIds.has(threadDomId(thread)));
     const projectSupplementIds = renderProjectSupplementalHistory(missingNative, nativeIds);
+    const sidebarBasenames = collectSidebarProjectBasenames();
     const missing = missingNative.filter((thread) => {
       if (projectSupplementIds.has(threadDomId(thread))) return false;
-      return !threadHasVisibleProject(thread, projectRoots);
+      if (threadHasVisibleProject(thread, projectRoots)) return false;
+      if (sidebarBasenames.size > 0) {
+        const cwdParts = normalizePathForCompare(thread.cwd).split("/").filter(Boolean);
+        if (cwdParts.some((part) => sidebarBasenames.has(part))) return false;
+      }
+      return true;
     });
     const nextIds = missing.map((thread) => threadDomId(thread)).join("|");
     const existing = document.querySelector(SUPPLEMENT_SELECTOR);

--- a/scripts/codex-list-pagebuster.js
+++ b/scripts/codex-list-pagebuster.js
@@ -298,12 +298,19 @@
   }
 
   function collectVisibleProjectRoots() {
-    const roots = new Set(
-      Array.from(document.querySelectorAll("[data-app-action-sidebar-project-id]"))
-        .map((row) => row.getAttribute("data-app-action-sidebar-project-id"))
-        .map(normalizePathForCompare)
-        .filter(Boolean)
-    );
+    const roots = new Set();
+    const addRoot = (value) => {
+      const root = normalizePathForCompare(value);
+      if (root) roots.add(root);
+    };
+
+    for (const row of document.querySelectorAll("[data-app-action-sidebar-project-id]")) {
+      addRoot(row.getAttribute("data-app-action-sidebar-project-id"));
+    }
+    for (const projectList of document.querySelectorAll(PROJECT_LIST_SELECTOR)) {
+      addRoot(projectList.getAttribute("data-app-action-sidebar-project-list-id"));
+    }
+
     if (roots.size > 0) {
       return rememberProjectRoots(roots);
     }


### PR DESCRIPTION
﻿## 概要

- 新增 `codex-list-pagebuster` Codex++ 用户脚本。
- 在 `index.json` 中登记脚本信息，并将脚本文件放入 `scripts/` 目录。
- 脚本用于补强 Codex Desktop 左侧会话列表，显示更多本地历史会话。
- 脚本只处理前端侧边栏显示，不修改账号、请求、额度状态或 API Key。

## 说明

Codex Desktop 左侧会话列表有时只加载最近约 50 条会话。即使历史会话已经被本地恢复功能修复、并能被当前配置识别，也可能不会直接显示在侧边栏里。

`codex-list-pagebuster` 处理这个前端列表限制：

- 尝试把缺失会话导入 Codex 原生 recent cache。
- 对无法进入原生列表的会话提供 `Extra history` 兜底入口。
- 过滤归档会话和内部 guardian/subagent 会话。
- 尊重用户手动折叠的项目列表，不会把折叠项重新弹出。

Homepage: https://github.com/puppnn/codex-plusplus-list-pagebuster

## 验证

- `node --check scripts/codex-list-pagebuster.js`
- 已确认 `index.json` 可以正常解析。
- 已在本地 Codex++ 用户脚本目录加载验证。
