### PR TITLE
Fix codex-token-usage checksum

### DIFF
--- a/index.json
+++ b/index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-05-25T08:46:56Z",
+  "updated_at": "2026-05-26T01:14:41Z",
   "scripts": [
     {
       "id": "codex-context-used-meter",
@@ -49,7 +49,7 @@
       ],
       "homepage": "https://github.com/kokotao/codex-token-usage-script",
       "script_url": "https://raw.githubusercontent.com/BigPizzaV3/CodexPlusPlusScriptMarket/main/scripts/codex-token-usage.js",
-      "sha256": "a163bd62d886cd738adaa3966cfc92465892cea2cc9d4fd1dabecc4cc517fd2a"
+      "sha256": "cee3188c1a90083f27c01d3e1d48af42b074b0e38f05507c970f18145f376ad5"
     },
     {
       "id": "codex-list-pagebuster",


### PR DESCRIPTION
## Summary\n- Update codex-token-usage script sha256 to match the current script content\n- Refresh marketplace updated_at timestamp\n\n## Verification\n- Verified local script SHA-256 equals index.json sha256: cee3188c1a90083f27c01d3e1d48af42b074b0e38f05507c970f18145f376ad5\n- Verified remote raw script SHA-256 returns the same value