### PR TITLE
Update Codex List Pagebuster global history fallback

### DIFF
--- a/index.json
+++ b/index.json
@@ -71,8 +71,8 @@
     {
       "id": "codex-list-pagebuster",
       "name": "Codex List Pagebuster",
-      "description": "补强 Codex Desktop 左侧原生会话列表，显示更多本地历史会话，并为无法进入原生列表的旧会话提供兜底入口。",
-      "version": "0.1.0",
+      "description": "补强 Codex Desktop 左侧原生会话列表，优先从本地全局历史拉取更多会话，并为无法进入原生列表的旧会话提供兜底入口。",
+      "version": "0.1.1",
       "author": "puppnn",
       "tags": [
         "codex",
@@ -81,9 +81,9 @@
         "sessions",
         "ui"
       ],
-      "homepage": "https://github.com/puppnn/codex-plusplus-list-pagebuster",
+      "homepage": "https://github.com/BigPizzaV3/CodexPlusPlusScriptMarket",
       "script_url": "https://raw.githubusercontent.com/BigPizzaV3/CodexPlusPlusScriptMarket/main/scripts/codex-list-pagebuster.js",
-      "sha256": "7fb991273eda02538a22186d6c5891c4b67aff0d59491f3fde7cb396e2117e77"
+      "sha256": "756ee2e2a91df449738192ae500de1ab75cbbc7129968982ca37f6f5a9aad78e"
     }
   ]
 }

--- a/scripts/codex-list-pagebuster.js
+++ b/scripts/codex-list-pagebuster.js
@@ -1,7 +1,11 @@
 (() => {
-  const TARGET = 500;
+  const TARGET = 1000;
+  const CLI_PAGE_SIZE = 100;
+  const CLI_MAX_PAGES = 20;
   const SCRIPT_KEY = "__codexListPagebuster";
   const STORAGE_KEY = "__codexListPagebusterThreads";
+  const STORAGE_VERSION_KEY = "__codexListPagebusterStorageVersion";
+  const STORAGE_VERSION = "2026-06-01-global-history-v4";
   const PROJECT_LIST_SELECTOR = "[data-app-action-sidebar-project-list-id]";
   const THREAD_SELECTOR = "[data-app-action-sidebar-thread-id]";
   const SUPPLEMENT_SELECTOR = "[data-clpb-history-section]";
@@ -12,6 +16,7 @@
   const LIMIT_KEYS = ["limit", "pageSize", "page_size", "first", "take", "perPage", "per_page", "count", "max", "size", "n"];
   const ARCHIVED_IDS_KEY = "__codexListPagebusterArchivedIds";
   const HIDDEN_IDS_KEY = "__codexListPagebusterHiddenIds";
+  const GLOBAL_EXTRA_HISTORY = true;
   const SIGNALS_MODULE_RE = /(?:\.\/)?assets\/app-server-manager-signals-[A-Za-z0-9_-]+\.js/g;
   const SIGNALS_MODULE_FALLBACKS = [
     "./assets/app-server-manager-signals-Csopz8aM.js",
@@ -261,6 +266,26 @@
     }
   }
 
+  function migrateStorageForGlobalHistory() {
+    try {
+      const version = localStorage.getItem(STORAGE_VERSION_KEY);
+      if (version === STORAGE_VERSION) return;
+      // Earlier builds could keep a current-project-only snapshot or hide
+      // old cross-project threads after a failed metadata check. Rebuild from
+      // the broad local CLI history on the next refresh.
+      localStorage.removeItem(STORAGE_KEY);
+      localStorage.removeItem(HIDDEN_IDS_KEY);
+      localStorage.setItem(STORAGE_VERSION_KEY, STORAGE_VERSION);
+      state.supplementIds = "";
+      log("global history storage migrated", {
+        previousVersion: version || "(none)",
+        version: STORAGE_VERSION
+      });
+    } catch (error) {
+      log("global history storage migration failed", String(error));
+    }
+  }
+
   function pruneSnapshotThreads(idsToRemove) {
     const removeSet = new Set(Array.from(idsToRemove).map(threadRawId).filter(Boolean));
     if (removeSet.size === 0) return 0;
@@ -296,6 +321,18 @@
     }
     if (changed) writeHiddenIds(hiddenIds);
     return hiddenIds;
+  }
+
+  function snapshotProjectCounts(limit = 12) {
+    const counts = new Map();
+    for (const thread of readSnapshotThreads()) {
+      const label = basename(thread.cwd);
+      counts.set(label, (counts.get(label) || 0) + 1);
+    }
+    return Array.from(counts.entries())
+      .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+      .slice(0, limit)
+      .map(([project, count]) => ({ project, count }));
   }
 
   function collectSidebarProjectBasenames() {
@@ -623,19 +660,33 @@
     });
   }
 
-  async function listThreadsFromCli({ archived, limit = TARGET }) {
+  function threadListParams({ archived, cursor, global }) {
+    const params = {
+      archived,
+      cursor,
+      limit: CLI_PAGE_SIZE,
+      sortKey: "updated_at"
+    };
+    if (global) {
+      return {
+        ...params,
+        modelProviders: [],
+        sourceKinds: ["cli", "vscode", "appServer", "unknown"],
+        useStateDbOnly: true,
+        includeAllWorkspaces: true,
+        includeAllProjects: true
+      };
+    }
+    return { ...params, modelProviders: null };
+  }
+
+  async function listThreadsFromCliVariant({ archived, limit, global }) {
     const threads = [];
     let cursor = null;
-    for (let page = 0; page < 20 && threads.length < limit; page += 1) {
+    for (let page = 0; page < CLI_MAX_PAGES && threads.length < limit; page += 1) {
       const result = await sendCliRequest(
         "thread/list",
-        {
-          archived,
-          cursor,
-          limit: 50,
-          modelProviders: null,
-          sortKey: "updated_at"
-        },
+        threadListParams({ archived, cursor, global }),
         { timeoutMs: 12000 }
       );
       const data = Array.isArray(result?.data) ? result.data : [];
@@ -644,6 +695,18 @@
       if (!cursor || data.length === 0) break;
     }
     return threads;
+  }
+
+  async function listThreadsFromCli({ archived, limit = TARGET }) {
+    if (!GLOBAL_EXTRA_HISTORY) {
+      return listThreadsFromCliVariant({ archived, limit, global: false });
+    }
+    try {
+      return await listThreadsFromCliVariant({ archived, limit, global: true });
+    } catch (error) {
+      log("global thread/list failed; retrying default scope", String(error));
+      return listThreadsFromCliVariant({ archived, limit, global: false });
+    }
   }
 
   async function refreshSnapshotFromCli(force = false) {
@@ -1121,13 +1184,29 @@
   window[SCRIPT_KEY] = {
     expand: () => expandNativeProjectLists("manual"),
     open: openThread,
+    refresh: () => refreshSnapshotFromCli(true),
+    resetHistory: () => {
+      localStorage.removeItem(STORAGE_KEY);
+      localStorage.removeItem(HIDDEN_IDS_KEY);
+      localStorage.setItem(STORAGE_VERSION_KEY, STORAGE_VERSION);
+      state.supplementIds = "";
+      refreshSnapshotFromCli(true);
+      scheduleExpand("reset-history");
+    },
+    render: renderSupplementalHistory,
     status: () => ({
       projects: document.querySelectorAll(PROJECT_LIST_SELECTOR).length,
       threads: document.querySelectorAll(THREAD_SELECTOR).length,
       nativeThreads: collectNativeThreadIds().size,
       supplementThreads: document.querySelectorAll("[data-clpb-supplemental-row]").length,
+      projectSupplementItems: document.querySelectorAll(PROJECT_SUPPLEMENT_ITEM_SELECTOR).length,
       snapshotThreads: readSnapshotThreads().length,
       missingNativeThreads: readSnapshotThreads().filter((thread) => !collectNativeThreadIds().has(threadDomId(thread))).length,
+      snapshotProjects: snapshotProjectCounts(20),
+      historySectionText: document.querySelector(SUPPLEMENT_SELECTOR)?.innerText || "",
+      lastSnapshotRefreshAt: state.lastSnapshotRefreshAt,
+      snapshotRefreshInFlight: state.snapshotRefreshInFlight,
+      globalExtraHistory: GLOBAL_EXTRA_HISTORY,
       expandButtons: countExpandButtons(),
       href: location.href
     }),
@@ -1136,8 +1215,9 @@
 
   patchRequests();
   installObserver();
+  migrateStorageForGlobalHistory();
   log("loaded", window[SCRIPT_KEY].status());
-  refreshSnapshotFromCli();
+  refreshSnapshotFromCli(true);
   scheduleExpand("load");
   renderSupplementalHistory();
   [250, 750, 1500, 3000].forEach((ms) => {


### PR DESCRIPTION
## Summary

- Increase the Pagebuster target to 1000 entries and fetch larger CLI pages.
- Prefer a global local-history `thread/list` query across workspaces/projects, with a fallback to the previous scoped query.
- Migrate stale current-project-only localStorage snapshots and expose `refresh`, `resetHistory`, `render`, and richer `status()` diagnostics.
- Bump `codex-list-pagebuster` to `0.1.1` and update the market SHA-256.

## Privacy / packaging note

This PR intentionally does **not** include any local static thread seeds, local Windows paths, thread IDs, or user-specific titles. It only publishes the generic Pagebuster logic needed to rebuild the Extra History list from Codex Desktop local history at runtime.

## Verification

- `node --check scripts/codex-list-pagebuster.js`
- `JSON.parse` check for `index.json`
- SHA-256 in `index.json` matches `scripts/codex-list-pagebuster.js`
- Searched for local/private markers: no matches for user paths, project names, thread IDs, or static seed constants