### PR TITLE
chore: update hide usage alert to 0.1.1

### DIFF
--- a/index.json
+++ b/index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-06-02T11:14:21.482Z",
+  "updated_at": "2026-06-03T12:58:49.419Z",
   "scripts": [
     {
       "id": "codex-context-ring-restore",
@@ -39,7 +39,7 @@
       "id": "hide-usage-alert",
       "name": "Hide Usage Alert",
       "description": "隐藏 Codex Desktop 的额度提醒，适合 Codex++ 远程同步搭配 API Key 使用时减少 Free/Plus 账号额度弹窗干扰。",
-      "version": "4",
+      "version": "0.1.1",
       "author": "Ghibli1024",
       "tags": [
         "usage",
@@ -48,8 +48,8 @@
         "hide"
       ],
       "homepage": "https://github.com/Ghibli1024/codex-hide-usage-alert",
-      "script_url": "https://raw.githubusercontent.com/BigPizzaV3/CodexPlusPlusScriptMarket/1e8ba79da3efb629153d79eaad678b2a48a801c5/scripts/hide-usage-alert.js",
-      "sha256": "031d7767ad5022e0be36a6213942de60b346b527667b174472cca4d3d0742073"
+      "script_url": "https://raw.githubusercontent.com/BigPizzaV3/CodexPlusPlusScriptMarket/main/scripts/hide-usage-alert.js",
+      "sha256": "6f348e54d1be7367986d3e7cf349d21de74a87a47a1397cfcdb0715891b62bc3"
     },
     {
       "id": "codex-token-usage",

--- a/scripts/hide-usage-alert.js
+++ b/scripts/hide-usage-alert.js
@@ -2,7 +2,7 @@
   const API_KEY = "__codexPlusHideUsageAlert";
   const STYLE_ID = "codex-plus-hide-usage-alert-style";
   const HIDDEN_ATTR = "data-codex-plus-hidden-usage-alert";
-  const VERSION = 4;
+  const SCRIPT_VERSION = "0.1.1";
 
   const previous = window[API_KEY];
   if (previous && typeof previous.destroy === "function") {
@@ -18,9 +18,9 @@
   };
 
   const quotaBannerRe =
-    /(你的\s*Codex\s*消息限额已用尽|Codex\s*消息限额已用尽|message\s+limit|usage\s+limit)/i;
+    /(你的\s*Codex\s*消息限额已用尽|Codex\s*消息限额已用尽|message\s+limit|usage\s+limit|you['’]?re\s+out\s+of\s+Codex\s+messages|out\s+of\s+Codex\s+messages)/i;
   const quotaResetRe =
-    /(额度将于|继续使用\s*Codex|升级至\s*Plus|quota\s+will\s+reset|limit\s+will\s+reset|upgrade\s+to\s+plus)/i;
+    /(额度将于|继续使用\s*Codex|升级至\s*Plus|quota\s+will\s+reset|limit\s+will\s+reset|rate\s+limit\s+resets|resets?\s+on|continue\s+using\s+Codex|start\s+your\s+free\s+trial\s+of\s+Plus|upgrade\s+to\s+plus)/i;
   const usageCardRe =
     /(剩余\s*\d+%\s*使用量|重置频率|下次重置时间|remaining\s+\d+%\s+usage|usage\s+remaining|reset\s+frequency|next\s+reset)/i;
   const actionTextRe =
@@ -210,13 +210,13 @@
     }
     state.hidden.clear();
     document.getElementById(STYLE_ID)?.remove();
-    if (window[API_KEY]?.version === VERSION) {
+    if (window[API_KEY]?.version === SCRIPT_VERSION) {
       delete window[API_KEY];
     }
   }
 
   window[API_KEY] = {
-    version: VERSION,
+    version: SCRIPT_VERSION,
     state,
     scan,
     destroy,


### PR DESCRIPTION
## What changed

- Update `scripts/hide-usage-alert.js` to `0.1.1`.
- Include support for the new English usage alert popup/banner copy (`You're out of Codex messages`).
- Update the `hide-usage-alert` entry in `index.json`.
- Refresh the SHA-256 checksum.

## Source

Ported from `Ghibli1024/codex-hide-usage-alert@a330faf`.

Original PR: https://github.com/Ghibli1024/codex-hide-usage-alert/pull/1

## Validation

- `node --check scripts/hide-usage-alert.js`
- `python3 -m json.tool index.json >/dev/null`
- checksum verified against `index.json`