### PR TITLE
fix: 修复 index.json JSON 格式错误 - codex-zhcn-translate 条目从 tags 数组移至 scripts 数组

### DIFF
--- a/index.json
+++ b/index.json
@@ -80,18 +80,18 @@
         "sidebar",
         "sessions",
         "ui"
-      {
+      ],
+      "homepage": "https://github.com/BigPizzaV3/CodexPlusPlusScriptMarket",
+      "script_url": "https://raw.githubusercontent.com/BigPizzaV3/CodexPlusPlusScriptMarket/main/scripts/codex-list-pagebuster.js",
+      "sha256": "756ee2e2a91df449738192ae500de1ab75cbbc7129968982ca37f6f5a9aad78e"
+    },
+    {
 "id": "codex-zhcn-translate",
 "name": "Codex简体中文汉化",
 "author": "hL091015",
 "script_url": "https://raw.githubusercontent.com/hL091015/CodexPlusPlusScriptMarket/main/scripts/zh_CN汉化.user.js",
 "sha256": "72214D31D425D1CE936B457AA43FCC40DF55F4DE3B9B140F9510C7F392CDC845",
 "description": "Codex客户端全界面简体汉化补丁"
-},
-      ],
-      "homepage": "https://github.com/BigPizzaV3/CodexPlusPlusScriptMarket",
-      "script_url": "https://raw.githubusercontent.com/BigPizzaV3/CodexPlusPlusScriptMarket/main/scripts/codex-list-pagebuster.js",
-      "sha256": "756ee2e2a91df449738192ae500de1ab75cbbc7129968982ca37f6f5a9aad78e"
-    }
+}
   ]
 }


### PR DESCRIPTION
## 问题描述

index.json 文件中，codex-list-pagebuster 条目的 	ags 数组末尾错误地嵌入了 codex-zhcn-translate 的完整条目，导致 JSON 格式错误，Codex++ 脚本市场加载失败。

## 修复内容

- 将 codex-zhcn-translate 从 codex-list-pagebuster 的 	ags 数组中移出
- 将 codex-zhcn-translate 作为 scripts 数组的独立元素，放在 codex-list-pagebuster 之后
- 确保 codex-list-pagebuster 的 	ags 数组正确闭合为 [" codex\, \history\, \sidebar\, \sessions\, \ui\]
- 修复后 JSON 语法验证通过