### PR TITLE
Fix: JSON syntax error in index.json

### DIFF
--- a/index.json
+++ b/index.json
@@ -79,19 +79,19 @@
         "history",
         "sidebar",
         "sessions",
-        "ui"
-      {
-"id": "codex-zhcn-translate",
-"name": "Codex简体中文汉化",
-"author": "hL091015",
-"script_url": "https://raw.githubusercontent.com/hL091015/CodexPlusPlusScriptMarket/main/scripts/zh_CN汉化.user.js",
-"sha256": "72214D31D425D1CE936B457AA43FCC40DF55F4DE3B9B140F9510C7F392CDC845",
-"description": "Codex客户端全界面简体汉化补丁"
-},
+                "ui"
       ],
       "homepage": "https://github.com/BigPizzaV3/CodexPlusPlusScriptMarket",
       "script_url": "https://raw.githubusercontent.com/BigPizzaV3/CodexPlusPlusScriptMarket/main/scripts/codex-list-pagebuster.js",
       "sha256": "756ee2e2a91df449738192ae500de1ab75cbbc7129968982ca37f6f5a9aad78e"
+    },
+    {
+      "id": "codex-zhcn-translate",
+      "name": "Codex简体中文汉化",
+      "author": "hL091015",
+      "script_url": "https://raw.githubusercontent.com/hL091015/CodexPlusPlusScriptMarket/main/scripts/zh_CN汉化.user.js",
+      "sha256": "72214D31D425D1CE936B457AA43FCC40DF55F4DE3B9B140F9510C7F392CDC845",
+      "description": "Codex客户端全界面简体汉化补丁"
     }
   ]
 }


### PR DESCRIPTION
…translate

The tags array for codex-list-pagebuster was missing closing brackets, causing two script entries to be merged. This fixes the JSON parsing error: 'failed to decode script market index JSON'

Fix missing ], between list-pagebuster and zhcn-translate entries causing "failed to decode script market index JSON"