### PR TITLE
fix(hide-usage-alert): match new Codex Chinese rate-limit banner

### DIFF
--- a/index.json
+++ b/index.json
@@ -39,7 +39,7 @@
       "id": "hide-usage-alert",
       "name": "Hide Usage Alert",
       "description": "隐藏额度提醒",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "author": "Ghibli1024",
       "tags": [
         "usage",
@@ -49,7 +49,7 @@
       ],
       "homepage": "",
       "script_url": "https://raw.githubusercontent.com/BigPizzaV3/CodexPlusPlusScriptMarket/main/scripts/hide-usage-alert.js",
-      "sha256": "6f348e54d1be7367986d3e7cf349d21de74a87a47a1397cfcdb0715891b62bc3"
+      "sha256": "b13279be9d6707c3109d0f71c7c1b56b2645cb659cbbca6a67f438022f3bae9c"
     },
     {
       "id": "codex-token-usage",

--- a/scripts/hide-usage-alert.js
+++ b/scripts/hide-usage-alert.js
@@ -2,7 +2,7 @@
   const API_KEY = "__codexPlusHideUsageAlert";
   const STYLE_ID = "codex-plus-hide-usage-alert-style";
   const HIDDEN_ATTR = "data-codex-plus-hidden-usage-alert";
-  const SCRIPT_VERSION = "0.1.1";
+  const SCRIPT_VERSION = "0.1.2";
 
   const previous = window[API_KEY];
   if (previous && typeof previous.destroy === "function") {
@@ -18,9 +18,9 @@
   };
 
   const quotaBannerRe =
-    /(你的\s*Codex\s*消息限额已用尽|Codex\s*消息限额已用尽|message\s+limit|usage\s+limit|you['’]?re\s+out\s+of\s+Codex\s+messages|out\s+of\s+Codex\s+messages)/i;
+    /(你的\s*Codex\s*消息限额已用尽|Codex\s*消息限额已用尽|message\s+limit|usage\s+limit|you['’]?re\s+out\s+of\s+Codex\s+messages|out\s+of\s+Codex\s+messages|你的\s*Codex\s*已用完|你的\s*Codex\s*消息\s*额度|你的\s*速率限制|速率限制\s*(?:将于|重置))/i;
   const quotaResetRe =
-    /(额度将于|继续使用\s*Codex|升级至\s*Plus|quota\s+will\s+reset|limit\s+will\s+reset|rate\s+limit\s+resets|resets?\s+on|continue\s+using\s+Codex|start\s+your\s+free\s+trial\s+of\s+Plus|upgrade\s+to\s+plus)/i;
+    /(额度将于|继续使用\s*Codex|升级至\s*Plus|quota\s+will\s+reset|limit\s+will\s+reset|rate\s+limit\s+resets|resets?\s+on|continue\s+using\s+Codex|start\s+your\s+free\s+trial\s+of\s+Plus|upgrade\s+to\s+plus|速率限制|将于\s*\d|重置)/i;
   const usageCardRe =
     /(剩余\s*\d+%\s*使用量|重置频率|下次重置时间|remaining\s+\d+%\s+usage|usage\s+remaining|reset\s+frequency|next\s+reset)/i;
   const actionTextRe =


### PR DESCRIPTION
## Problem

The Codex desktop client recently changed its Chinese rate-limit banner copy from the old wording (e.g. *"您已经用尽了您的 Codex 消息限额"*) to a new format:

```
您的速率限制将于 2026年6月14日 00:00 重置。立即升级，或現在使用一次速率限制重置机会。
```

Neither `quotaBannerRe` nor `quotaResetRe` in `scripts/hide-usage-alert.js` (v0.1.1) matches this new string, so `looksLikeQuotaBanner()` returns false and the banner stays visible even though the script is loaded and scanning.

I verified this in the running Codex renderer via Chrome DevTools Protocol: `window.__codexPlusHideUsageAlert.state.matches` stayed at `0` after 1668 scans.

## Fix

Append new alternations to both regexes while keeping all existing patterns, so the script still recognizes the old wording:

- `quotaBannerRe` adds: `你的\s*Codex\s*已用完`, `你的\s*Codex\s*消息\s*额度`, `你的\s*速率限制`, `速率限制\s*(?:将于|重置)`
- `quotaResetRe` adds: `速率限制`, `将于\s*\d`, `重置`

The other gates (`bannerBox`, `insideConversationContent`, `actionTextRe`, length window, `hasAction`) are unchanged, so false-positive risk stays the same as the original script.

## Verification

After applying the patch locally and re-running the patched script in a live Codex renderer:

- `window.__codexPlusHideUsageAlert.state.matches`: `0` → `2`
- Injected a synthetic banner with the exact string from the bug report → it was automatically tagged `data-codex-plus-hidden-usage-alert="true"` and computed `display: none`.

## Changes

- Bump `SCRIPT_VERSION` `0.1.1` → `0.1.2`
- Update `index.json` version + recompute sha256

## Out of scope

I noticed the related bug [BigPizzaV3/CodexPlusPlus#442](https://github.com/BigPizzaV3/CodexPlusPlus/issues/442) about Codex's CDP port binding only on IPv6 `[::1]` on some macOS / Electron versions — that affects all scripts, not just this one, so it deserves a separate PR in the CodexPlusPlus injector repo.