### PR TITLE
fix(hide-usage-alert): hide subagent quota cards

### DIFF
--- a/index.json
+++ b/index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-06-25T06:01:55.000Z",
+  "updated_at": "2026-07-04T08:39:43.000Z",
   "scripts": [
     {
       "id": "codex-context-ring-restore",
@@ -39,17 +39,17 @@
       "id": "hide-usage-alert",
       "name": "Hide Usage Alert",
       "description": "隐藏额度提醒",
-      "version": "0.1.2",
-      "author": "Ghibli1024",
+      "version": "0.1.3",
+      "author": "0xTotoroX",
       "tags": [
         "usage",
         "quota",
         "ui",
         "hide"
       ],
-      "homepage": "",
+      "homepage": "https://github.com/0xTotoroX/codex-hide-usage-alert",
       "script_url": "https://raw.githubusercontent.com/BigPizzaV3/CodexPlusPlusScriptMarket/main/scripts/hide-usage-alert.js",
-      "sha256": "b13279be9d6707c3109d0f71c7c1b56b2645cb659cbbca6a67f438022f3bae9c"
+      "sha256": "a120c224c9c7e1de25a3c2f0614fbd144842d75aa4569f9a40074da7795f74e5"
     },
     {
       "id": "codex-token-usage",

--- a/scripts/hide-usage-alert.js
+++ b/scripts/hide-usage-alert.js
@@ -2,7 +2,7 @@
   const API_KEY = "__codexPlusHideUsageAlert";
   const STYLE_ID = "codex-plus-hide-usage-alert-style";
   const HIDDEN_ATTR = "data-codex-plus-hidden-usage-alert";
-  const SCRIPT_VERSION = "0.1.2";
+  const SCRIPT_VERSION = "0.1.3";
 
   const previous = window[API_KEY];
   if (previous && typeof previous.destroy === "function") {
@@ -24,7 +24,7 @@
   const usageCardRe =
     /(剩余\s*\d+%\s*使用量|重置频率|下次重置时间|remaining\s+\d+%\s+usage|usage\s+remaining|reset\s+frequency|next\s+reset)/i;
   const actionTextRe =
-    /(升级|Plus|upgrade|pricing|plan|重置|reset|限额|limit|quota)/i;
+    /(升级|Plus|upgrade|pricing|plan|重置|reset|限额|额度|限制|limit|quota)/i;
 
   function normalizeText(value) {
     return String(value || "").replace(/\s+/g, " ").trim();
@@ -46,7 +46,7 @@
   function bannerBox(node) {
     if (!visibleBox(node)) return false;
     const rect = node.getBoundingClientRect();
-    if (rect.width < 300 || rect.height < 30 || rect.height > 120) return false;
+    if (rect.width < 300 || rect.height < 30 || rect.height > 220) return false;
     return true;
   }
 


### PR DESCRIPTION
## Summary

- Update Hide Usage Alert from `0.1.2` to `0.1.3`.
- Sync the standalone script update from https://github.com/0xTotoroX/codex-hide-usage-alert.
- Hide quota alerts rendered as taller card-like UI in subagent panels.
- Refresh `index.json` metadata: version, homepage, and SHA-256.

## Root Cause

The subagent panel can render the quota warning as a taller card instead of the old short bottom banner. The existing text match was close, but `bannerBox()` rejected the card because quota alerts taller than `120px` were ignored.

## Validation

- `node test-matchers.js` in `0xTotoroX/codex-hide-usage-alert`
- Verified `scripts/hide-usage-alert.js` matches the standalone source
- Verified `index.json` SHA-256 matches `scripts/hide-usage-alert.js`