### PR TITLE
perf: 优化 Codex Daily Token Usage 可用性与大会话刷新性能

### DIFF
--- a/index.json
+++ b/index.json
@@ -73,7 +73,7 @@
       "id": "codex-daily-token-usage",
       "name": "Codex Daily Token Usage",
       "description": "每日 Token 统计，近 5 日滚动存储，自动复用已有采集，支持 Model 价格、成本估算、趋势明细和分享图",
-      "version": "1.4.14",
+      "version": "1.4.15",
       "author": "kts-kris",
       "tags": [
         "codex",
@@ -85,7 +85,7 @@
       ],
       "homepage": "",
       "script_url": "https://raw.githubusercontent.com/BigPizzaV3/CodexPlusPlusScriptMarket/main/scripts/codex-daily-token-usage.js",
-      "sha256": "2abbc2e4d1ebb3160bbb325ede037a8b27cd6ba71bbe55f3d600394baf706e8a"
+      "sha256": "5c74b7051e5617a0d7d8e2f15d70870c131260990c3f98e1e5a0c665e39ae37d"
     },
     {
       "id": "codex-list-pagebuster",

--- a/index.json
+++ b/index.json
@@ -73,7 +73,7 @@
       "id": "codex-daily-token-usage",
       "name": "Codex Daily Token Usage",
       "description": "每日 Token 统计，近 5 日滚动存储，自动复用已有采集，支持 Model 价格、成本估算、趋势明细和分享图",
-      "version": "1.4.13",
+      "version": "1.4.14",
       "author": "kts-kris",
       "tags": [
         "codex",
@@ -85,7 +85,7 @@
       ],
       "homepage": "",
       "script_url": "https://raw.githubusercontent.com/BigPizzaV3/CodexPlusPlusScriptMarket/main/scripts/codex-daily-token-usage.js",
-      "sha256": "80f5efb88d1e2e0da5c22f229b65d08710460a7c258bdaea7b82a84071fb7576"
+      "sha256": "2abbc2e4d1ebb3160bbb325ede037a8b27cd6ba71bbe55f3d600394baf706e8a"
     },
     {
       "id": "codex-list-pagebuster",

--- a/scripts/codex-daily-token-usage.js
+++ b/scripts/codex-daily-token-usage.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Codex Daily Token Usage
 // @namespace    codex-plus-plus
-// @version      1.4.13
+// @version      1.4.14
 // @description  每日 Token 统计，近 5 日滚动存储，优先复用已有采集，必要时内置采集，支持 Model 价格、成本估算、日期切换、5 日趋势与分享图。
 // @match        app://-/*
 // @run-at       document-start
@@ -10,7 +10,7 @@
 (() => {
   "use strict";
 
-  const VERSION = "1.4.13";
+  const VERSION = "1.4.14";
   const API_KEY = "__codexDailyTokenUsage";
   const SOURCE_API_KEY = "__codexTokenUsage";
   const STORAGE_KEY = "__codexDailyTokenUsageV1";
@@ -2631,6 +2631,7 @@
       #${PANEL_ID} {
         position: fixed;
         width: min(350px, calc(100vw - 24px));
+        max-height: calc(100dvh - 24px);
         box-sizing: border-box;
         padding: 14px;
         border: 1px solid var(--color-token-border, rgba(127, 127, 127, 0.24));
@@ -2644,6 +2645,10 @@
         transition: opacity 120ms ease, visibility 120ms ease, transform 120ms ease;
         pointer-events: none;
         cursor: default;
+        overflow-x: hidden;
+        overflow-y: auto;
+        overscroll-behavior: contain;
+        scrollbar-width: thin;
         z-index: 2147483647;
         font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
         -webkit-app-region: no-drag;
@@ -2654,23 +2659,46 @@
         transform: translateY(0);
         pointer-events: auto;
       }
+      #${PANEL_ID}::-webkit-scrollbar {
+        width: 8px;
+      }
+      #${PANEL_ID}::-webkit-scrollbar-thumb {
+        border: 2px solid transparent;
+        border-radius: 999px;
+        background: rgba(127, 127, 127, 0.48);
+        background-clip: padding-box;
+      }
       #${PANEL_ID} .codex-daily-heading {
         display: flex;
         align-items: center;
         justify-content: space-between;
         gap: 12px;
-        margin-bottom: 12px;
+        position: sticky;
+        top: -14px;
+        z-index: 2;
+        margin: -14px -14px 12px;
+        padding: 14px 14px 12px;
+        border-bottom: 1px solid var(--color-token-border, rgba(127, 127, 127, 0.18));
+        background: var(--color-token-background, #ffffff);
+        flex-wrap: nowrap;
       }
       #${PANEL_ID} .codex-daily-title {
+        flex: 0 0 auto;
         font-size: 13px;
         font-weight: 650;
+        white-space: nowrap;
       }
       #${PANEL_ID} .codex-daily-head-actions {
         display: inline-flex;
+        min-width: 0;
+        flex: 1 1 auto;
         align-items: center;
+        justify-content: flex-end;
         gap: 6px;
+        white-space: nowrap;
       }
       #${PANEL_ID} .codex-daily-price-toggle {
+        flex: 0 0 auto;
         height: 29px;
         display: inline-flex;
         align-items: center;
@@ -2683,6 +2711,7 @@
         font: inherit;
         font-size: 11px;
         font-weight: 600;
+        white-space: nowrap;
       }
       #${PANEL_ID} .codex-daily-price-toggle:hover,
       #${PANEL_ID} .codex-daily-price-toggle[aria-expanded="true"] {
@@ -2691,6 +2720,7 @@
         background: rgba(74, 144, 226, 0.11);
       }
       #${PANEL_ID} .codex-daily-date-nav {
+        flex: 0 0 auto;
         display: inline-flex;
         align-items: center;
         gap: 3px;
@@ -2736,6 +2766,27 @@
         font-size: 11px;
         line-height: 23px;
         color-scheme: light dark;
+      }
+      @media (max-width: 420px) {
+        #${PANEL_ID} .codex-daily-heading {
+          gap: 7px;
+        }
+        #${PANEL_ID} .codex-daily-head-actions {
+          gap: 4px;
+        }
+        #${PANEL_ID} .codex-daily-price-toggle {
+          padding: 0 6px;
+        }
+        #${PANEL_ID} .codex-daily-date-nav {
+          gap: 1px;
+          padding: 2px 1px;
+        }
+        #${PANEL_ID} .codex-daily-date-button {
+          width: 21px;
+        }
+        #${PANEL_ID} .codex-daily-date-input {
+          width: 88px;
+        }
       }
       #${PANEL_ID} .codex-daily-summary {
         display: flex;
@@ -3089,9 +3140,6 @@
       #${PANEL_ID} .codex-daily-price-list {
         display: grid;
         gap: 9px;
-        max-height: 260px;
-        overflow: auto;
-        padding-right: 2px;
       }
       #${PANEL_ID} .codex-daily-price-row {
         display: grid;
@@ -3143,7 +3191,13 @@
         align-items: center;
         justify-content: space-between;
         gap: 10px;
-        margin-top: 11px;
+        position: sticky;
+        bottom: -14px;
+        z-index: 2;
+        margin: 11px -14px -14px;
+        padding: 10px 14px 14px;
+        border-top: 1px solid var(--color-token-border, rgba(127, 127, 127, 0.18));
+        background: var(--color-token-background, #ffffff);
         color: var(--color-token-foreground-secondary, #737373);
         font-size: 11px;
         line-height: 1.45;
@@ -3217,6 +3271,22 @@
         #${PANEL_ID} {
           background: var(--color-token-background, #202020);
           color: var(--color-token-foreground, #f2f2f2);
+        }
+        #${PANEL_ID} .codex-daily-heading,
+        #${PANEL_ID} .codex-daily-foot {
+          background: var(--color-token-background, #202020);
+        }
+        #${PANEL_ID} .codex-daily-price-model-input,
+        #${PANEL_ID} .codex-daily-price-input {
+          color: #f2f2f2;
+          caret-color: #f2f2f2;
+          border-color: rgba(255, 255, 255, 0.18);
+          background: rgba(255, 255, 255, 0.1);
+        }
+        #${PANEL_ID} .codex-daily-price-model-input::placeholder,
+        #${PANEL_ID} .codex-daily-price-input::placeholder {
+          color: rgba(242, 242, 242, 0.48);
+          opacity: 1;
         }
       }
     `;
@@ -3558,6 +3628,14 @@
         `;
         return row;
       })
+    );
+  }
+
+  function isEditingPriceSettings() {
+    const active = document.activeElement;
+    return Boolean(
+      active?.classList?.contains("codex-daily-price-model-input") ||
+        active?.classList?.contains("codex-daily-price-input")
     );
   }
 
@@ -4190,7 +4268,7 @@
     renderPanelTrend(buildTrendData(selectedDateKey));
     renderModelBreakdown(snapshot);
     renderToolCalls(snapshot);
-    if (panel.querySelector(".codex-daily-price-panel")?.hidden === false) {
+    if (panel.querySelector(".codex-daily-price-panel")?.hidden === false && !isEditingPriceSettings()) {
       renderPriceSettings(snapshot);
     }
 

--- a/scripts/codex-daily-token-usage.js
+++ b/scripts/codex-daily-token-usage.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Codex Daily Token Usage
 // @namespace    codex-plus-plus
-// @version      1.4.14
+// @version      1.4.15
 // @description  每日 Token 统计，近 5 日滚动存储，优先复用已有采集，必要时内置采集，支持 Model 价格、成本估算、日期切换、5 日趋势与分享图。
 // @match        app://-/*
 // @run-at       document-start
@@ -10,7 +10,7 @@
 (() => {
   "use strict";
 
-  const VERSION = "1.4.14";
+  const VERSION = "1.4.15";
   const API_KEY = "__codexDailyTokenUsage";
   const SOURCE_API_KEY = "__codexTokenUsage";
   const STORAGE_KEY = "__codexDailyTokenUsageV1";
@@ -149,9 +149,12 @@
   let captureSeq = 0;
   let externalEmptyCount = 0;
   let lastRenderedTotal = -1;
+  let lastRenderSignature = "";
   let lastDateKey = getDateKey(Date.now());
   let selectedDateKey = lastDateKey;
   let state = loadState();
+  const dayVersions = new Map();
+  const daySnapshotCache = new Map();
   if (pruneState()) saveState();
   let priceConfig = loadPriceConfig();
   let lastObservedModel = "";
@@ -808,10 +811,25 @@
       const timestamp = Date.parse(`${key}T00:00:00`);
       if (!Number.isFinite(timestamp) || timestamp < cutoff.getTime()) {
         delete state.days[key];
+        invalidateDay(key);
         changed = true;
       }
     }
     return changed;
+  }
+
+  function invalidateDay(dateKey) {
+    const normalized = String(dateKey || "");
+    if (!normalized) return 0;
+    const version = (dayVersions.get(normalized) || 0) + 1;
+    dayVersions.set(normalized, version);
+    daySnapshotCache.delete(normalized);
+    return version;
+  }
+
+  function clearDaySnapshotCache() {
+    dayVersions.clear();
+    daySnapshotCache.clear();
   }
 
   function upsertTurn(turn) {
@@ -858,6 +876,7 @@
           updatedAt: Math.max(existing.updatedAt || 0, candidate.updatedAt),
         };
         state.days[dateKey] = day;
+        invalidateDay(dateKey);
         return true;
       }
       return false;
@@ -899,6 +918,7 @@
     }
 
     state.days[dateKey] = day;
+    invalidateDay(dateKey);
     return true;
   }
 
@@ -925,6 +945,7 @@
       if (!day.toolEvents[persistedEventKey]) {
         day.toolEvents[persistedEventKey] = compactToolEvent(event, now);
         state.days[dateKey] = day;
+        invalidateDay(dateKey);
         return true;
       }
       return false;
@@ -970,6 +991,7 @@
     }
 
     state.days[dateKey] = day;
+    invalidateDay(dateKey);
     return true;
   }
 
@@ -1040,12 +1062,94 @@
     return best?.id || "";
   }
 
+  function buildTurnIndexes(turnEntries) {
+    const byIdentityKey = new Map();
+    const byConversationKey = new Map();
+    const allByTimestamp = [];
+    const unscopedByTimestamp = [];
+
+    for (const [id, turn] of turnEntries) {
+      const entry = { id, turn, timestamp: toCount(turn?.updatedAt) };
+      for (const key of turnIdentityKeys(id, turn)) {
+        if (!byIdentityKey.has(key)) byIdentityKey.set(key, id);
+      }
+      const conversationKeys = turnConversationKeys(turn);
+      if (conversationKeys.length) {
+        for (const key of conversationKeys) {
+          if (!byConversationKey.has(key)) byConversationKey.set(key, []);
+          byConversationKey.get(key).push(entry);
+        }
+      } else {
+        unscopedByTimestamp.push(entry);
+      }
+      allByTimestamp.push(entry);
+    }
+
+    const byTimestamp = (left, right) => left.timestamp - right.timestamp;
+    allByTimestamp.sort(byTimestamp);
+    unscopedByTimestamp.sort(byTimestamp);
+    for (const entries of byConversationKey.values()) entries.sort(byTimestamp);
+    return { byIdentityKey, byConversationKey, allByTimestamp, unscopedByTimestamp };
+  }
+
+  function firstTimestampIndex(entries, timestamp) {
+    let low = 0;
+    let high = entries.length;
+    while (low < high) {
+      const middle = Math.floor((low + high) / 2);
+      if (entries[middle].timestamp < timestamp) low = middle + 1;
+      else high = middle;
+    }
+    return low;
+  }
+
+  function nearestIndexedTurnId(event, indexes) {
+    const timestamp = toolEventUsageTimestamp(event);
+    if (!timestamp) return "";
+    const eventKeys = conversationKeyVariants(event?.conversationKey);
+    const lists = eventKeys.length
+      ? [...new Set(eventKeys.map((key) => indexes.byConversationKey.get(key)).filter(Boolean)), indexes.unscopedByTimestamp]
+      : [indexes.allByTimestamp];
+    let best = null;
+
+    for (const entries of lists) {
+      const start = firstTimestampIndex(entries, timestamp);
+      for (const direction of [-1, 1]) {
+        for (let index = direction < 0 ? start - 1 : start; index >= 0 && index < entries.length; index += direction) {
+          const entry = entries[index];
+          const distance = Math.abs(entry.timestamp - timestamp);
+          if (distance > TOOL_USAGE_MATCH_WINDOW_MS) break;
+          if (!eventConversationMatchesTurn(event, entry.turn)) continue;
+          const score = distance + (entry.timestamp >= timestamp ? 0 : TOOL_USAGE_MATCH_WINDOW_MS / 2);
+          if (!best || score < best.score) best = { id: entry.id, score };
+        }
+      }
+    }
+    return best?.id || "";
+  }
+
+  function linkToolEventsIndexed(turnEntries, toolEvents) {
+    const indexes = buildTurnIndexes(turnEntries);
+    const matchedTurnIds = new Set();
+    let estimated = false;
+    for (const event of toolEvents) {
+      const exactId = conversationKeyVariants(event?.turnKey)
+        .map((key) => indexes.byIdentityKey.get(key))
+        .find(Boolean);
+      const matchedId = exactId || nearestIndexedTurnId(event, indexes);
+      if (!matchedId) continue;
+      matchedTurnIds.add(matchedId);
+      if (!exactId) estimated = true;
+    }
+    return { matchedTurnIds, estimated };
+  }
+
   function calculateTurnCost(turn) {
     const costInfo = calculateUsageCost(turn, getModelPrice(displayModelName(turn?.model)));
     return costInfo.configured ? costInfo.cost : 0;
   }
 
-  function aggregateDay(dateKey = getDateKey(Date.now())) {
+  function buildDaySnapshot(dateKey = getDateKey(Date.now())) {
     const day = state.days[dateKey] || {};
     const turnEntries = Object.entries(day.turns || {});
     const turns = turnEntries.map(([, turn]) => turn);
@@ -1141,7 +1245,9 @@
       .filter(Boolean);
     const toolTurnsByKey = new Map();
     const toolTurnKeys = new Set();
-    const matchedTurnIds = new Set();
+    const linkedToolTurns = linkToolEventsIndexed(turnEntries, toolEvents);
+    const matchedTurnIds = linkedToolTurns.matchedTurnIds;
+    summary.toolLinkedEstimated = linkedToolTurns.estimated;
     for (const event of toolEvents) {
       const key = toolCallKey(event.kind, event.namespace, event.name);
       const turnKey = normalizeConversationKey(event.turnKey);
@@ -1151,12 +1257,6 @@
         toolTurnsByKey.get(key).add(turnKey);
       }
 
-      const exactTurnId = findExactToolTurnId(event, turnEntries);
-      const matchedTurnId = exactTurnId || findNearestToolTurnId(event, turnEntries);
-      if (matchedTurnId) {
-        matchedTurnIds.add(matchedTurnId);
-        if (!exactTurnId) summary.toolLinkedEstimated = true;
-      }
     }
 
     for (const toolCall of Object.values(day.toolCalls || {})) {
@@ -1208,6 +1308,32 @@
     delete summary.modelsByName;
     delete summary.toolCallsByKey;
     return summary;
+  }
+
+  function aggregateDayCached(dateKey = getDateKey(Date.now())) {
+    const normalized = String(dateKey || getDateKey(Date.now()));
+    const version = dayVersions.get(normalized) || 0;
+    const cached = daySnapshotCache.get(normalized);
+    if (cached?.version === version) {
+      return { snapshot: cached.snapshot, cacheHit: true, version };
+    }
+    const snapshot = buildDaySnapshot(normalized);
+    daySnapshotCache.set(normalized, { version, snapshot });
+    return { snapshot, cacheHit: false, version };
+  }
+
+  function aggregateDay(dateKey = getDateKey(Date.now())) {
+    return aggregateDayCached(dateKey).snapshot;
+  }
+
+  function renderStateSignature(todayKey = getDateKey(Date.now()), dateKey = selectedDateKey) {
+    const selectedKey = clampDateKey(dateKey);
+    const trendVersions = [];
+    for (let offset = 0; offset < TREND_DAYS; offset += 1) {
+      const trendDateKey = shiftDateKey(selectedKey, -offset);
+      trendVersions.push(`${trendDateKey}:${dayVersions.get(trendDateKey) || 0}`);
+    }
+    return `${sourceMode}|${todayKey}:${dayVersions.get(todayKey) || 0}|${selectedKey}:${dayVersions.get(selectedKey) || 0}|${trendVersions.join(",")}`;
   }
 
   function formatTrendDateLabel(dateKey) {
@@ -4278,6 +4404,7 @@
       root.classList.add("is-updated");
       window.setTimeout(() => root?.classList.remove("is-updated"), 450);
     }
+    lastRenderSignature = renderStateSignature(todayKey, selectedDateKey);
   }
 
   function scheduleMidnightRefresh() {
@@ -4310,13 +4437,18 @@
     const sourceChanged = syncFromSource();
     const domToolChanged = processDomToolCalls();
     const changed = sourceChanged || domToolChanged;
-    mountRoot();
-    render({ animate: changed });
+    const signature = renderStateSignature(currentDateKey, selectedDateKey);
+    if (signature !== lastRenderSignature) {
+      mountRoot();
+      render({ animate: changed });
+    }
     return aggregateDay();
   }
 
   function resetToday() {
-    delete state.days[getDateKey(Date.now())];
+    const dateKey = getDateKey(Date.now());
+    delete state.days[dateKey];
+    invalidateDay(dateKey);
     saveState();
     render();
     return aggregateDay();
@@ -4392,6 +4524,10 @@
       isUsageTurn,
       upsertTurn,
       aggregateDay,
+      aggregateDayCached,
+      linkToolEventsIndexed,
+      renderStateSignature,
+      recordTurnForTest: (turn) => upsertTurn(turn),
       formatCompact,
       buildTrendData,
       trendPoints,
@@ -4413,6 +4549,7 @@
       },
       replaceState(nextState) {
         state = nextState;
+        clearDaySnapshotCache();
       },
     },
   };


### PR DESCRIPTION
## Summary

优化 `Codex Daily Token Usage` 的小屏幕、暗色模式和大会话性能体验，并更新脚本索引校验信息。

## UI Fixes

- 限制弹层最大高度为当前视口，超长内容可通过外层面板滚动访问。
- 移除价格列表的内层滚动，避免双滚动条。
- 将标题栏固定在顶部、状态与分享栏固定在底部，滚动时关键操作仍可见。
- 优化窄视口布局：
  - 标题、价格按钮和日期控件保持单行显示。
  - 缩窄滚动条与日期控件，减少可用宽度被挤压的问题。
- 修复暗色模式下价格输入框白底白字、内容不可见的问题。
- 修复编辑价格或添加 Model 时，定时刷新重建 DOM 导致输入框自动失焦的问题。

## Performance Improvements

- 为每日统计结果增加内存缓存；未发生数据变化时复用已聚合快照。
- 新增按日期的缓存失效机制，仅在对应日期的 turn 或工具调用数据变化后重新计算。
- 将工具事件与 turn 的关联从逐事件遍历全部 turn，改为预构建 turn 标识索引和按时间二分查找。
- 刷新逻辑改为基于数据版本触发，仅在统计数据或数据源状态变化时重绘面板。
- 更新脚本版本至 `1.4.15`，并同步 `index.json` 中的版本与 SHA-256。

## Performance Validation

在 Issue #62 所使用的同一大会话中复测：

| 指标 | 修复前 | 修复后 |
| --- | ---: | ---: |
| 2026-07-20 聚合耗时 | 348.1ms | 缓存命中，低于计时精度 |
| 完整 `refresh()` 耗时 | 370.6ms | 2.1ms |
| 7 月 20 日数据规模 | 226 turn / 314 工具事件 | 保持不变 |

CPU 采样中，`conversationKeyVariants`、`turnIdentityKeys` 和 `turnConversationKeys` 不再是刷新热点。

实际体感Codex卡顿已经消失
## Screenshot

<img width="522" height="1491" alt="Updated daily token usage panel" src="https://github.com/user-attachments/assets/b5ad69d5-787a-40bc-9aef-751e18224033" />

## Validation

- `node --check scripts/codex-daily-token-usage.js`
- 验证 `index.json` 可正常解析，版本为 `1.4.15`。
- 验证 `index.json` 登记的 SHA-256 与脚本文件一致。
- 使用 Chrome DevTools 在原大会话中完成性能复测。

Related to #35  
Closes #62