### PR TITLE
feat: update Hide Usage Alert to 0.1.5

### DIFF
--- a/index.json
+++ b/index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-07-16T08:27:07Z",
+  "updated_at": "2026-07-26T14:30:31Z",
   "scripts": [
     {
       "id": "codex-context-used-meter",
@@ -21,8 +21,8 @@
     {
       "id": "hide-usage-alert",
       "name": "Hide Usage Alert",
-      "description": "隐藏额度提醒",
-      "version": "0.1.4",
+      "description": "隐藏额度提醒与顶栏获取 Plus 按钮",
+      "version": "0.1.5",
       "author": "0xTotoroX",
       "tags": [
         "usage",
@@ -32,7 +32,7 @@
       ],
       "homepage": "https://github.com/0xTotoroX/codex-hide-usage-alert",
       "script_url": "https://raw.githubusercontent.com/BigPizzaV3/CodexPlusPlusScriptMarket/main/scripts/hide-usage-alert.js",
-      "sha256": "29fb7eb5b44cda3281ddcaed5174746c02b0a8b9de461c49774bb3746a3cda7b"
+      "sha256": "c7e907e998bfc3d4153302fa84dfb0b1e4fa16d6e738db669713a84872f631d6"
     },
     {
       "id": "model-deck",

--- a/scripts/hide-usage-alert.js
+++ b/scripts/hide-usage-alert.js
@@ -6,7 +6,7 @@
   const HIDDEN_ATTR = "data-codex-plus-hidden-usage-alert";
   const HIDDEN_KIND_ATTR = `${HIDDEN_ATTR}-kind`;
   const HIDDEN_MARKER_SELECTOR = `[${HIDDEN_ATTR}], [${HIDDEN_KIND_ATTR}]`;
-  const SCRIPT_VERSION = "0.1.4";
+  const SCRIPT_VERSION = "0.1.5";
   const PROTECTED_SURFACE_SELECTOR = [
     "[data-codex-composer-root]",
     "[data-codex-composer]",
@@ -50,6 +50,9 @@
     /(剩余\s*\d+%\s*使用量|重置频率|下次重置时间|remaining\s+\d+%\s+usage|usage\s+remaining|reset\s+frequency|next\s+reset)/i;
   const actionTextRe =
     /(升级|Plus|upgrade|pricing|plan|重置|reset|限额|额度|限制|limit|quota)/i;
+  const plusUpsellRe =
+    /^(?:获取|开通|升级(?:至|到)?|免费试用|试用|Get|Try|Upgrade(?:\s+to)?)\s*(?:ChatGPT\s*)?Plus$/i;
+  const PLUS_UPSELL_SELECTOR = "button, a, [role='button']";
 
   function normalizeText(value) {
     return String(value || "").replace(/\s+/g, " ").trim();
@@ -138,6 +141,22 @@
     return usageCardBox(node);
   }
 
+  function looksLikePlusUpsell(node) {
+    if (!node.matches(PLUS_UPSELL_SELECTOR)) return false;
+    if (!node.closest("header")) return false;
+    if (intersectsConversationContent(node)) return false;
+    return plusUpsellRe.test(candidateText(node));
+  }
+
+  function scanPlusUpsell(root) {
+    const nodes = Array.from(root.querySelectorAll(PLUS_UPSELL_SELECTOR));
+    if (root.matches(PLUS_UPSELL_SELECTOR)) nodes.unshift(root);
+    for (const node of nodes) {
+      if (node.closest(`[${HIDDEN_ATTR}="true"]`)) continue;
+      if (looksLikePlusUpsell(node)) hideNode(node, "plus-upsell");
+    }
+  }
+
   function hideNode(node, kind) {
     if (!isElement(node) || node === document.body || node === document.documentElement) return false;
     if (node.getAttribute(HIDDEN_ATTR) === "true") return false;
@@ -208,6 +227,7 @@
   function scanSubtree(root) {
     if (!isElement(root)) return false;
     state.scans += 1;
+    scanPlusUpsell(root);
     for (const node of collectCandidates(root)) classifyCandidate(node);
     return true;
   }


### PR DESCRIPTION
## 更新内容

Hide Usage Alert 0.1.4 -> 0.1.5：

- 新增顶栏「获取 Plus / Get Plus / 升级至 Plus / 免费试用 Plus」升级按钮隐藏，标记 kind 为 plus-upsell
- 规则只匹配 header 内 button/a/[role=button] 的完整短文本，不触碰会话内容区，避免误杀正文里提到 Plus 的消息
- 复用既有 scanSubtree + MutationObserver + hideNode 链路，无新增 observer，生命周期语义不变

## 市场元数据

- index.json：version 0.1.5、description 与 sha256 同步更新，updated_at 已刷新
- scripts/hide-usage-alert.js 与独立仓库 main 的发布产物逐字节一致

## 验证

- 独立仓库：node test-matchers.js 全部通过（fail 0），node --check 通过
- 市场分支：node --check、jq 结构校验、id 唯一性校验、sha256 一致性校验、git diff --check 全部通过
- 实机：CDP 热注入 Codex Desktop 主页面，header 中动态渲染的获取 Plus 按钮约 300ms 内被隐藏，observer 存活

SHA-256: c7e907e998bfc3d4153302fa84dfb0b1e4fa16d6e738db669713a84872f631d6

上游发布源: https://github.com/0xTotoroX/codex-hide-usage-alert