### PR TITLE
feat: add ChatGPT Message Navigator

### DIFF
--- a/index.json
+++ b/index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-08-19T07:14:44Z",
+  "updated_at": "2026-08-19T07:25:10Z",
   "scripts": [
     {
       "id": "codex-context-used-meter",
@@ -245,8 +245,8 @@
     {
       "id": "chatgpt-message-navigator",
       "name": "ChatGPT Message Navigator",
-      "description": "为 Codex Desktop 的 ChatGPT 模式增加长对话消息导航，支持完整历史面板、始终可见的右侧滑轨、滚轮逐条切换、拖动跳转和阅读位置高亮。",
-      "version": "1.1.1",
+      "description": "为 Codex Desktop 的 ChatGPT 模式增加长对话消息导航，支持完整历史面板、可见滑轨、滚轮切换、拖动跳转，并修复切换聊天后回弹到最早历史的问题。",
+      "version": "1.1.4",
       "author": "Takizzl",
       "tags": [
         "chatgpt",
@@ -257,7 +257,7 @@
       ],
       "homepage": "https://github.com/Takizzl/chatgpt-message-navigator",
       "script_url": "https://raw.githubusercontent.com/BigPizzaV3/CodexPlusPlusScriptMarket/main/scripts/chatgpt-message-navigator.js",
-      "sha256": "78f38c512c1e0e75187d393c853c7f4eaba05e8e5c3e0e545054deff2158066d"
+      "sha256": "4be947fb03db871ee09c45e37c8b9977ab540b0e34970ddf5b29c005fa0c44c4"
     }
   ]
 }

--- a/index.json
+++ b/index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-08-19T06:43:57Z",
+  "updated_at": "2026-08-19T07:07:04Z",
   "scripts": [
     {
       "id": "codex-context-used-meter",
@@ -245,8 +245,8 @@
     {
       "id": "chatgpt-message-navigator",
       "name": "ChatGPT Message Navigator",
-      "description": "为 Codex Desktop 的 ChatGPT 模式增加类似 Codex 的长对话消息导航条，支持提问跳转、悬停摘要、阅读位置高亮和自动更新。",
-      "version": "1.0.0",
+      "description": "为 Codex Desktop 的 ChatGPT 模式增加类似 Codex 的长对话消息导航条，支持完整历史面板、滚轮浏览、拖动滚动条、提问跳转和阅读位置高亮。",
+      "version": "1.1.0",
       "author": "Takizzl",
       "tags": [
         "chatgpt",
@@ -257,7 +257,7 @@
       ],
       "homepage": "https://github.com/Takizzl/chatgpt-message-navigator",
       "script_url": "https://raw.githubusercontent.com/BigPizzaV3/CodexPlusPlusScriptMarket/main/scripts/chatgpt-message-navigator.js",
-      "sha256": "d039b75770cfd52f9608d5120b569cbbd8ce9acc1e4ceb5ba33da02a6f01a5c0"
+      "sha256": "6a199af613d2bc44141a9bf9646cf96f486ed564413a1a99b3cfb9e6cf2a228e"
     }
   ]
 }

--- a/index.json
+++ b/index.json
@@ -245,8 +245,8 @@
     {
       "id": "chatgpt-message-navigator",
       "name": "ChatGPT Message Navigator",
-      "description": "为 Codex Desktop 的 ChatGPT 模式增加长对话消息导航，支持完整历史面板、可见滑轨、滚轮切换、拖动跳转，并修复切换聊天后回弹到最早历史的问题。",
-      "version": "1.1.4",
+      "description": "为 Codex Desktop 的 ChatGPT 模式增加完整用户提问导航：短线点击跳转、悬停预览、滚轮选取，不显示回答、不干扰正文滚动。",
+      "version": "1.1.11",
       "author": "Takizzl",
       "tags": [
         "chatgpt",
@@ -257,7 +257,7 @@
       ],
       "homepage": "https://github.com/Takizzl/chatgpt-message-navigator",
       "script_url": "https://raw.githubusercontent.com/BigPizzaV3/CodexPlusPlusScriptMarket/main/scripts/chatgpt-message-navigator.js",
-      "sha256": "4be947fb03db871ee09c45e37c8b9977ab540b0e34970ddf5b29c005fa0c44c4"
+      "sha256": "574f355344ec6dd448401cbb4687f2976dbcd9c780f7f12135ae3da7219fc7e4"
     }
   ]
 }

--- a/index.json
+++ b/index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-07-28T03:17:39Z",
+  "updated_at": "2026-08-19T06:43:57Z",
   "scripts": [
     {
       "id": "codex-context-used-meter",
@@ -241,6 +241,23 @@
       "homepage": "",
       "script_url": "https://raw.githubusercontent.com/BigPizzaV3/CodexPlusPlusScriptMarket/main/scripts/Codex%20Model%20Matrix.js",
       "sha256": "0a25838a887699f8c8b72efc67f64d9df045697f6e1555b856fb10a9baa8f075"
+    },
+    {
+      "id": "chatgpt-message-navigator",
+      "name": "ChatGPT Message Navigator",
+      "description": "为 Codex Desktop 的 ChatGPT 模式增加类似 Codex 的长对话消息导航条，支持提问跳转、悬停摘要、阅读位置高亮和自动更新。",
+      "version": "1.0.0",
+      "author": "Takizzl",
+      "tags": [
+        "chatgpt",
+        "navigation",
+        "history",
+        "ui",
+        "productivity"
+      ],
+      "homepage": "https://github.com/Takizzl/chatgpt-message-navigator",
+      "script_url": "https://raw.githubusercontent.com/BigPizzaV3/CodexPlusPlusScriptMarket/main/scripts/chatgpt-message-navigator.js",
+      "sha256": "d039b75770cfd52f9608d5120b569cbbd8ce9acc1e4ceb5ba33da02a6f01a5c0"
     }
   ]
 }

--- a/index.json
+++ b/index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-08-19T07:07:04Z",
+  "updated_at": "2026-08-19T07:14:44Z",
   "scripts": [
     {
       "id": "codex-context-used-meter",
@@ -245,8 +245,8 @@
     {
       "id": "chatgpt-message-navigator",
       "name": "ChatGPT Message Navigator",
-      "description": "为 Codex Desktop 的 ChatGPT 模式增加类似 Codex 的长对话消息导航条，支持完整历史面板、滚轮浏览、拖动滚动条、提问跳转和阅读位置高亮。",
-      "version": "1.1.0",
+      "description": "为 Codex Desktop 的 ChatGPT 模式增加长对话消息导航，支持完整历史面板、始终可见的右侧滑轨、滚轮逐条切换、拖动跳转和阅读位置高亮。",
+      "version": "1.1.1",
       "author": "Takizzl",
       "tags": [
         "chatgpt",
@@ -257,7 +257,7 @@
       ],
       "homepage": "https://github.com/Takizzl/chatgpt-message-navigator",
       "script_url": "https://raw.githubusercontent.com/BigPizzaV3/CodexPlusPlusScriptMarket/main/scripts/chatgpt-message-navigator.js",
-      "sha256": "6a199af613d2bc44141a9bf9646cf96f486ed564413a1a99b3cfb9e6cf2a228e"
+      "sha256": "78f38c512c1e0e75187d393c853c7f4eaba05e8e5c3e0e545054deff2158066d"
     }
   ]
 }

--- a/scripts/chatgpt-message-navigator.js
+++ b/scripts/chatgpt-message-navigator.js
@@ -5,13 +5,16 @@
   const API_KEY = "__chatgptMessageNavigator";
   const ROOT_ID = "chatgpt-message-navigator";
   const STYLE_ID = "chatgpt-message-navigator-style";
-  const VERSION = "1.0.0";
+  const VERSION = "1.1.0";
 
   if (window[API_KEY]?.destroy) window[API_KEY].destroy();
 
   let root = null;
   let list = null;
   let tooltip = null;
+  let panel = null;
+  let panelList = null;
+  let panelCount = null;
   let scrollContainer = null;
   let messageTargets = [];
   let activeIndex = -1;
@@ -101,6 +104,109 @@
       color: color-mix(in srgb, currentColor 55%, transparent);
       font-size: 11px;
     }
+    #${ROOT_ID}:hover .cgpt-nav-tooltip,
+    #${ROOT_ID}:focus-within .cgpt-nav-tooltip { opacity: 0 !important; }
+    #${ROOT_ID} .cgpt-nav-panel {
+      position: absolute;
+      left: 32px;
+      top: 50%;
+      display: flex;
+      width: min(390px, calc(100vw - 100px));
+      max-height: min(82vh, 860px);
+      flex-direction: column;
+      overflow: hidden;
+      border: 1px solid color-mix(in srgb, currentColor 14%, transparent);
+      border-radius: 14px;
+      background: color-mix(in srgb, var(--color-background-primary, #fff) 96%, transparent);
+      box-shadow: 0 14px 38px rgba(0, 0, 0, .18);
+      color: var(--color-text, #202123);
+      opacity: 0;
+      visibility: hidden;
+      transform: translateY(-50%) translateX(-6px);
+      transition: opacity 120ms ease, transform 120ms ease, visibility 120ms ease;
+      pointer-events: auto;
+    }
+    #${ROOT_ID}:hover .cgpt-nav-panel,
+    #${ROOT_ID}:focus-within .cgpt-nav-panel {
+      opacity: 1;
+      visibility: visible;
+      transform: translateY(-50%) translateX(0);
+    }
+    #${ROOT_ID} .cgpt-nav-panel-header {
+      display: flex;
+      min-height: 42px;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      padding: 0 12px;
+      border-bottom: 1px solid color-mix(in srgb, currentColor 10%, transparent);
+      color: color-mix(in srgb, currentColor 68%, transparent);
+      font-size: 12px;
+      font-weight: 600;
+    }
+    #${ROOT_ID} .cgpt-nav-panel-hint {
+      font-size: 11px;
+      font-weight: 400;
+      opacity: .72;
+    }
+    #${ROOT_ID} .cgpt-nav-panel-list {
+      display: flex;
+      max-height: calc(min(82vh, 860px) - 43px);
+      flex-direction: column;
+      gap: 2px;
+      overflow-x: hidden;
+      overflow-y: auto;
+      overscroll-behavior: contain;
+      padding: 7px;
+      scrollbar-gutter: stable;
+      scrollbar-width: thin;
+      scrollbar-color: color-mix(in srgb, currentColor 27%, transparent) transparent;
+    }
+    #${ROOT_ID} .cgpt-nav-panel-list::-webkit-scrollbar { width: 10px; }
+    #${ROOT_ID} .cgpt-nav-panel-list::-webkit-scrollbar-track { background: transparent; }
+    #${ROOT_ID} .cgpt-nav-panel-list::-webkit-scrollbar-thumb {
+      border: 3px solid transparent;
+      border-radius: 999px;
+      background: color-mix(in srgb, currentColor 28%, transparent);
+      background-clip: padding-box;
+    }
+    #${ROOT_ID} .cgpt-nav-panel-item {
+      display: grid;
+      width: 100%;
+      min-height: 34px;
+      grid-template-columns: 28px minmax(0, 1fr);
+      align-items: center;
+      gap: 4px;
+      padding: 5px 9px 5px 5px;
+      border: 0;
+      border-radius: 9px;
+      background: transparent;
+      color: inherit;
+      cursor: pointer;
+      font: inherit;
+      text-align: left;
+    }
+    #${ROOT_ID} .cgpt-nav-panel-item:hover,
+    #${ROOT_ID} .cgpt-nav-panel-item:focus-visible {
+      background: color-mix(in srgb, currentColor 8%, transparent);
+      outline: none;
+    }
+    #${ROOT_ID} .cgpt-nav-panel-item[data-active="true"] {
+      background: color-mix(in srgb, currentColor 10%, transparent);
+    }
+    #${ROOT_ID} .cgpt-nav-panel-index {
+      color: color-mix(in srgb, currentColor 46%, transparent);
+      font-size: 10px;
+      text-align: right;
+    }
+    #${ROOT_ID} .cgpt-nav-panel-text {
+      min-width: 0;
+      overflow: hidden;
+      font-size: 12px;
+      line-height: 1.4;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
     @media (prefers-reduced-motion: reduce) {
       #${ROOT_ID} *, #${ROOT_ID} *::before, #${ROOT_ID} *::after { transition: none !important; }
     }
@@ -133,7 +239,31 @@
     tooltip.className = "cgpt-nav-tooltip";
     tooltip.setAttribute("role", "tooltip");
 
-    root.append(list, tooltip);
+    panel = document.createElement("section");
+    panel.className = "cgpt-nav-panel";
+    panel.setAttribute("aria-label", "全部历史提问");
+
+    const panelHeader = document.createElement("div");
+    panelHeader.className = "cgpt-nav-panel-header";
+    panelCount = document.createElement("span");
+    const panelHint = document.createElement("span");
+    panelHint.className = "cgpt-nav-panel-hint";
+    panelHint.textContent = "滚轮或拖动滚动条";
+    panelHeader.append(panelCount, panelHint);
+
+    panelList = document.createElement("div");
+    panelList.className = "cgpt-nav-panel-list";
+    panelList.setAttribute("role", "list");
+    panelList.addEventListener("wheel", (event) => event.stopPropagation(), { passive: true });
+    list.addEventListener("wheel", (event) => {
+      if (panelList.scrollHeight <= panelList.clientHeight) return;
+      event.preventDefault();
+      panelList.scrollTop += event.deltaY;
+    }, { passive: false });
+
+    panel.append(panelHeader, panelList);
+
+    root.append(list, tooltip, panel);
     document.body.appendChild(root);
   }
 
@@ -204,6 +334,8 @@
     messageTargets = nextBubbles;
     activeIndex = -1;
     list.replaceChildren();
+    panelList.replaceChildren();
+    panelCount.textContent = `全部提问 · ${nextBubbles.length}`;
 
     nextBubbles.forEach((bubble, index) => {
       const text = messageText(bubble);
@@ -220,6 +352,22 @@
       button.addEventListener("mouseleave", hideTooltip);
       button.addEventListener("blur", hideTooltip);
       list.appendChild(button);
+
+      const panelButton = document.createElement("button");
+      panelButton.type = "button";
+      panelButton.className = "cgpt-nav-panel-item";
+      panelButton.dataset.index = String(index);
+      panelButton.setAttribute("role", "listitem");
+      panelButton.setAttribute("aria-label", `跳转到第 ${index + 1} 条提问：${text}`);
+      const number = document.createElement("span");
+      number.className = "cgpt-nav-panel-index";
+      number.textContent = String(index + 1);
+      const label = document.createElement("span");
+      label.className = "cgpt-nav-panel-text";
+      label.textContent = text;
+      panelButton.append(number, label);
+      panelButton.addEventListener("click", () => jumpTo(index));
+      panelList.appendChild(panelButton);
     });
   }
 
@@ -261,6 +409,11 @@
         if (index === next) button.setAttribute("aria-current", "true");
         else button.removeAttribute("aria-current");
       });
+      [...panelList.children].forEach((button, index) => {
+        button.dataset.active = String(index === next);
+        if (index === next) button.setAttribute("aria-current", "true");
+        else button.removeAttribute("aria-current");
+      });
 
       const activeButton = list.children[next];
       if (activeButton) {
@@ -269,6 +422,15 @@
         if (top < list.scrollTop) list.scrollTop = Math.max(0, top - 8);
         else if (bottom > list.scrollTop + list.clientHeight) {
           list.scrollTop = bottom - list.clientHeight + 8;
+        }
+      }
+      const activePanelButton = panelList.children[next];
+      if (activePanelButton) {
+        const top = activePanelButton.offsetTop;
+        const bottom = top + activePanelButton.offsetHeight;
+        if (top < panelList.scrollTop) panelList.scrollTop = Math.max(0, top - 7);
+        else if (bottom > panelList.scrollTop + panelList.clientHeight) {
+          panelList.scrollTop = bottom - panelList.clientHeight + 7;
         }
       }
     });
@@ -336,7 +498,7 @@
     window.removeEventListener("resize", positionRoot);
     root?.remove();
     style.remove();
-    root = list = tooltip = null;
+    root = list = tooltip = panel = panelList = panelCount = null;
     messageTargets = [];
     delete window[INSTALL_KEY];
     delete window[API_KEY];

--- a/scripts/chatgpt-message-navigator.js
+++ b/scripts/chatgpt-message-navigator.js
@@ -1,0 +1,348 @@
+(() => {
+  "use strict";
+
+  const INSTALL_KEY = "__chatgptMessageNavigatorInstalled";
+  const API_KEY = "__chatgptMessageNavigator";
+  const ROOT_ID = "chatgpt-message-navigator";
+  const STYLE_ID = "chatgpt-message-navigator-style";
+  const VERSION = "1.0.0";
+
+  if (window[API_KEY]?.destroy) window[API_KEY].destroy();
+
+  let root = null;
+  let list = null;
+  let tooltip = null;
+  let scrollContainer = null;
+  let messageTargets = [];
+  let activeIndex = -1;
+  let updateTimer = 0;
+  let frame = 0;
+
+  const style = document.createElement("style");
+  style.id = STYLE_ID;
+  style.textContent = `
+    #${ROOT_ID} {
+      position: fixed;
+      z-index: 2147483000;
+      display: flex;
+      align-items: center;
+      pointer-events: none;
+      color: var(--color-text, #202123);
+      font-family: var(--font-sans, "Segoe UI", sans-serif);
+    }
+    #${ROOT_ID}[hidden] { display: none !important; }
+    #${ROOT_ID} .cgpt-nav-list {
+      display: flex;
+      max-height: min(68vh, 680px);
+      width: 28px;
+      flex-direction: column;
+      align-items: flex-start;
+      gap: 5px;
+      overflow-x: hidden;
+      overflow-y: auto;
+      padding: 8px 5px;
+      border-radius: 10px;
+      scrollbar-width: none;
+      pointer-events: auto;
+    }
+    #${ROOT_ID} .cgpt-nav-list::-webkit-scrollbar { display: none; }
+    #${ROOT_ID} .cgpt-nav-item {
+      display: block;
+      width: 8px;
+      min-height: 3px;
+      height: 3px;
+      margin: 0;
+      padding: 0;
+      flex: 0 0 3px;
+      border: 0;
+      border-radius: 999px;
+      background: color-mix(in srgb, currentColor 27%, transparent);
+      cursor: pointer;
+      outline: none;
+      transition: width 120ms ease, background-color 120ms ease, transform 120ms ease;
+    }
+    #${ROOT_ID} .cgpt-nav-item:hover,
+    #${ROOT_ID} .cgpt-nav-item:focus-visible {
+      width: 17px;
+      background: color-mix(in srgb, currentColor 62%, transparent);
+    }
+    #${ROOT_ID} .cgpt-nav-item[data-active="true"] {
+      width: 20px;
+      height: 4px;
+      min-height: 4px;
+      flex-basis: 4px;
+      background: color-mix(in srgb, currentColor 78%, transparent);
+    }
+    #${ROOT_ID} .cgpt-nav-tooltip {
+      position: absolute;
+      left: 33px;
+      width: min(330px, calc(100vw - 100px));
+      padding: 8px 10px;
+      border: 1px solid color-mix(in srgb, currentColor 14%, transparent);
+      border-radius: 9px;
+      background: color-mix(in srgb, var(--color-background-primary, #fff) 94%, transparent);
+      box-shadow: 0 8px 28px rgba(0, 0, 0, .16);
+      color: var(--color-text, #202123);
+      font-size: 12px;
+      line-height: 1.45;
+      white-space: normal;
+      word-break: break-word;
+      opacity: 0;
+      transform: translateY(-50%) translateX(-4px);
+      transition: opacity 90ms ease, transform 90ms ease;
+      pointer-events: none;
+    }
+    #${ROOT_ID} .cgpt-nav-tooltip[data-open="true"] {
+      opacity: 1;
+      transform: translateY(-50%) translateX(0);
+    }
+    #${ROOT_ID} .cgpt-nav-tooltip .cgpt-nav-number {
+      margin-bottom: 3px;
+      color: color-mix(in srgb, currentColor 55%, transparent);
+      font-size: 11px;
+    }
+    @media (prefers-reduced-motion: reduce) {
+      #${ROOT_ID} *, #${ROOT_ID} *::before, #${ROOT_ID} *::after { transition: none !important; }
+    }
+  `;
+  document.getElementById(STYLE_ID)?.remove();
+  document.head.appendChild(style);
+
+  function isChatGPTMode() {
+    const localized = document.querySelector(
+      'button[aria-label*="当前模式：ChatGPT"], button[aria-label*="current mode: ChatGPT" i]'
+    );
+    if (localized) return true;
+    return [...document.querySelectorAll('button[aria-haspopup="menu"]')].some(
+      (button) => (button.textContent || "").trim() === "ChatGPT"
+    );
+  }
+
+  function ensureRoot() {
+    if (root?.isConnected) return;
+    root = document.createElement("nav");
+    root.id = ROOT_ID;
+    root.setAttribute("aria-label", "ChatGPT 历史消息导航");
+    root.hidden = true;
+
+    list = document.createElement("div");
+    list.className = "cgpt-nav-list";
+    list.setAttribute("role", "list");
+
+    tooltip = document.createElement("div");
+    tooltip.className = "cgpt-nav-tooltip";
+    tooltip.setAttribute("role", "tooltip");
+
+    root.append(list, tooltip);
+    document.body.appendChild(root);
+  }
+
+  function getConversation() {
+    return document.querySelector('[data-thread-find-target="conversation"]');
+  }
+
+  function getScrollContainer(conversation) {
+    return conversation?.closest(".thread-scroll-container") ||
+      conversation?.parentElement?.closest(".thread-scroll-container") ||
+      [...document.querySelectorAll("div")].find((element) => {
+        const css = getComputedStyle(element);
+        return /(auto|scroll)/.test(css.overflowY) &&
+          element.scrollHeight > element.clientHeight + 100 &&
+          element.contains(conversation);
+      }) || null;
+  }
+
+  function getUserMessageTargets(conversation) {
+    const keyedUnits = [...conversation.querySelectorAll("[data-content-search-unit-key]")]
+      .filter((unit) => (unit.getAttribute("data-content-search-unit-key") || "").endsWith(":user"));
+    if (keyedUnits.length) return keyedUnits;
+
+    return [...conversation.querySelectorAll("h4")]
+      .filter((heading) => /^(你说：?|You said:?)$/i.test((heading.textContent || "").trim()))
+      .map((heading) => heading.nextElementSibling || heading);
+  }
+
+  function messageText(target) {
+    const raw = (target.innerText || target.textContent || "")
+      .replace(/\s+/g, " ")
+      .trim();
+    if (!raw) return "（附件或空消息）";
+    return raw.length > 110 ? `${raw.slice(0, 110)}…` : raw;
+  }
+
+  function setTooltip(button, index, text) {
+    const listRect = list.getBoundingClientRect();
+    const buttonRect = button.getBoundingClientRect();
+    const center = buttonRect.top + buttonRect.height / 2 - listRect.top;
+    tooltip.style.top = `${Math.max(18, Math.min(listRect.height - 18, center))}px`;
+    tooltip.innerHTML = "";
+    const number = document.createElement("div");
+    number.className = "cgpt-nav-number";
+    number.textContent = `第 ${index + 1} 条提问`;
+    const content = document.createElement("div");
+    content.textContent = text;
+    tooltip.append(number, content);
+    tooltip.dataset.open = "true";
+  }
+
+  function hideTooltip() {
+    if (tooltip) tooltip.dataset.open = "false";
+  }
+
+  function jumpTo(index) {
+    const target = messageTargets[index];
+    if (!target?.isConnected) return;
+    target.scrollIntoView({
+      behavior: "auto",
+      block: "center",
+      inline: "nearest",
+    });
+    window.setTimeout(() => updateActive(true), 180);
+  }
+
+  function renderItems(nextBubbles) {
+    messageTargets = nextBubbles;
+    activeIndex = -1;
+    list.replaceChildren();
+
+    nextBubbles.forEach((bubble, index) => {
+      const text = messageText(bubble);
+      const button = document.createElement("button");
+      button.type = "button";
+      button.className = "cgpt-nav-item";
+      button.dataset.index = String(index);
+      button.setAttribute("role", "listitem");
+      button.setAttribute("aria-label", `跳转到第 ${index + 1} 条提问：${text}`);
+      button.title = `第 ${index + 1} 条提问：${text}`;
+      button.addEventListener("click", () => jumpTo(index));
+      button.addEventListener("mouseenter", () => setTooltip(button, index, text));
+      button.addEventListener("focus", () => setTooltip(button, index, text));
+      button.addEventListener("mouseleave", hideTooltip);
+      button.addEventListener("blur", hideTooltip);
+      list.appendChild(button);
+    });
+  }
+
+  function sameMessages(next) {
+    return next.length === messageTargets.length &&
+      next.every((element, index) => element === messageTargets[index]);
+  }
+
+  function positionRoot() {
+    if (!root || root.hidden || !scrollContainer) return;
+    const rect = scrollContainer.getBoundingClientRect();
+    root.style.left = `${Math.max(8, rect.left + 16)}px`;
+    root.style.top = `${Math.max(90, rect.top + rect.height / 2)}px`;
+    root.style.transform = "translateY(-50%)";
+  }
+
+  function updateActive(force = false) {
+    cancelAnimationFrame(frame);
+    frame = requestAnimationFrame(() => {
+      if (root?.hidden || !scrollContainer || !messageTargets.length) return;
+      const viewport = scrollContainer.getBoundingClientRect();
+      const guide = viewport.top + Math.min(viewport.height * 0.38, 360);
+      let next = 0;
+      let best = Number.POSITIVE_INFINITY;
+
+      messageTargets.forEach((target, index) => {
+        const rect = target.getBoundingClientRect();
+        const distance = Math.abs(rect.top - guide);
+        if (distance < best) {
+          best = distance;
+          next = index;
+        }
+      });
+
+      if (!force && next === activeIndex) return;
+      activeIndex = next;
+      [...list.children].forEach((button, index) => {
+        button.dataset.active = String(index === next);
+        if (index === next) button.setAttribute("aria-current", "true");
+        else button.removeAttribute("aria-current");
+      });
+
+      const activeButton = list.children[next];
+      if (activeButton) {
+        const top = activeButton.offsetTop;
+        const bottom = top + activeButton.offsetHeight;
+        if (top < list.scrollTop) list.scrollTop = Math.max(0, top - 8);
+        else if (bottom > list.scrollTop + list.clientHeight) {
+          list.scrollTop = bottom - list.clientHeight + 8;
+        }
+      }
+    });
+  }
+
+  function detachScroll() {
+    scrollContainer?.removeEventListener("scroll", updateActive);
+    scrollContainer = null;
+  }
+
+  function refresh() {
+    ensureRoot();
+    if (!isChatGPTMode()) {
+      root.hidden = true;
+      hideTooltip();
+      detachScroll();
+      messageTargets = [];
+      return;
+    }
+
+    const conversation = getConversation();
+    const nextScroll = getScrollContainer(conversation);
+    const nextBubbles = conversation
+      ? getUserMessageTargets(conversation)
+          .filter((target) => !target.closest(`#${ROOT_ID}`))
+      : [];
+
+    if (!nextScroll || !nextBubbles.length) {
+      root.hidden = true;
+      return;
+    }
+
+    if (nextScroll !== scrollContainer) {
+      detachScroll();
+      scrollContainer = nextScroll;
+      scrollContainer.addEventListener("scroll", updateActive, { passive: true });
+    }
+    if (!sameMessages(nextBubbles)) renderItems(nextBubbles);
+
+    root.hidden = false;
+    positionRoot();
+    updateActive(true);
+  }
+
+  function scheduleRefresh(delay = 120) {
+    clearTimeout(updateTimer);
+    updateTimer = window.setTimeout(refresh, delay);
+  }
+
+  const observer = new MutationObserver((mutations) => {
+    if (mutations.every((mutation) => root?.contains(mutation.target))) return;
+    scheduleRefresh();
+  });
+  observer.observe(document.body, { childList: true, subtree: true });
+
+  const interval = window.setInterval(() => scheduleRefresh(0), 1200);
+  window.addEventListener("resize", positionRoot);
+
+  function destroy() {
+    clearTimeout(updateTimer);
+    clearInterval(interval);
+    cancelAnimationFrame(frame);
+    observer.disconnect();
+    detachScroll();
+    window.removeEventListener("resize", positionRoot);
+    root?.remove();
+    style.remove();
+    root = list = tooltip = null;
+    messageTargets = [];
+    delete window[INSTALL_KEY];
+    delete window[API_KEY];
+  }
+
+  window[INSTALL_KEY] = VERSION;
+  window[API_KEY] = { version: VERSION, refresh, destroy };
+  refresh();
+})();

--- a/scripts/chatgpt-message-navigator.js
+++ b/scripts/chatgpt-message-navigator.js
@@ -5,23 +5,20 @@
   const API_KEY = "__chatgptMessageNavigator";
   const ROOT_ID = "chatgpt-message-navigator";
   const STYLE_ID = "chatgpt-message-navigator-style";
-  const VERSION = "1.1.4";
+  const VERSION = "1.1.11";
 
   if (window[API_KEY]?.destroy) window[API_KEY].destroy();
 
   let root = null;
   let list = null;
   let tooltip = null;
-  let panel = null;
-  let panelList = null;
-  let panelCount = null;
-  let panelScrollbar = null;
-  let panelThumb = null;
   let lastWheelStepAt = 0;
+  let tooltipHideTimer = 0;
   let conversationKey = "";
   let scrollContainer = null;
   let messageTargets = [];
   let activeIndex = -1;
+  let selectedIndex = -1;
   let updateTimer = 0;
   let restoreLatestTimer = 0;
   let restoreLatestInterval = 0;
@@ -35,7 +32,7 @@
       position: fixed;
       z-index: 2147483000;
       display: flex;
-      align-items: center;
+      align-items: stretch;
       pointer-events: none;
       color: var(--color-text, #202123);
       font-family: var(--font-sans, "Segoe UI", sans-serif);
@@ -67,7 +64,7 @@
       border: 0;
       border-radius: 999px;
       background: color-mix(in srgb, currentColor 27%, transparent);
-      cursor: pointer;
+      cursor: default;
       outline: none;
       transition: width 120ms ease, background-color 120ms ease, transform 120ms ease;
     }
@@ -83,9 +80,13 @@
       flex-basis: 4px;
       background: color-mix(in srgb, currentColor 78%, transparent);
     }
+    #${ROOT_ID} .cgpt-nav-item[data-selected="true"] {
+      width: 20px;
+      background: color-mix(in srgb, currentColor 72%, transparent);
+    }
     #${ROOT_ID} .cgpt-nav-tooltip {
       position: absolute;
-      left: 33px;
+      left: 46px;
       width: min(330px, calc(100vw - 100px));
       padding: 8px 10px;
       border: 1px solid color-mix(in srgb, currentColor 14%, transparent);
@@ -110,132 +111,6 @@
       margin-bottom: 3px;
       color: color-mix(in srgb, currentColor 55%, transparent);
       font-size: 11px;
-    }
-    #${ROOT_ID}:hover .cgpt-nav-tooltip,
-    #${ROOT_ID}:focus-within .cgpt-nav-tooltip { opacity: 0 !important; }
-    #${ROOT_ID} .cgpt-nav-panel {
-      position: absolute;
-      left: 32px;
-      top: 50%;
-      display: flex;
-      width: min(390px, calc(100vw - 100px));
-      max-height: min(82vh, 860px);
-      flex-direction: column;
-      overflow: hidden;
-      border: 1px solid color-mix(in srgb, currentColor 14%, transparent);
-      border-radius: 14px;
-      background: color-mix(in srgb, var(--color-background-primary, #fff) 96%, transparent);
-      box-shadow: 0 14px 38px rgba(0, 0, 0, .18);
-      color: var(--color-text, #202123);
-      opacity: 0;
-      visibility: hidden;
-      transform: translateY(-50%) translateX(-6px);
-      transition: opacity 120ms ease, transform 120ms ease, visibility 120ms ease;
-      pointer-events: auto;
-    }
-    #${ROOT_ID}:hover .cgpt-nav-panel,
-    #${ROOT_ID}:focus-within .cgpt-nav-panel {
-      opacity: 1;
-      visibility: visible;
-      transform: translateY(-50%) translateX(0);
-    }
-    #${ROOT_ID} .cgpt-nav-panel-header {
-      display: flex;
-      min-height: 42px;
-      align-items: center;
-      justify-content: space-between;
-      gap: 12px;
-      padding: 0 12px;
-      border-bottom: 1px solid color-mix(in srgb, currentColor 10%, transparent);
-      color: color-mix(in srgb, currentColor 68%, transparent);
-      font-size: 12px;
-      font-weight: 600;
-    }
-    #${ROOT_ID} .cgpt-nav-panel-hint {
-      font-size: 11px;
-      font-weight: 400;
-      opacity: .72;
-    }
-    #${ROOT_ID} .cgpt-nav-panel-list {
-      display: flex;
-      max-height: calc(min(82vh, 860px) - 43px);
-      flex-direction: column;
-      gap: 2px;
-      overflow-x: hidden;
-      overflow-y: auto;
-      overscroll-behavior: contain;
-      padding: 7px;
-      scrollbar-width: none;
-    }
-    #${ROOT_ID} .cgpt-nav-panel-list::-webkit-scrollbar { display: none; }
-    #${ROOT_ID} .cgpt-nav-panel-body {
-      display: grid;
-      min-height: 0;
-      grid-template-columns: minmax(0, 1fr) 16px;
-    }
-    #${ROOT_ID} .cgpt-nav-scrollbar {
-      position: relative;
-      min-height: 48px;
-      margin: 8px 4px 8px 0;
-      border-radius: 999px;
-      background: color-mix(in srgb, currentColor 8%, transparent);
-      cursor: pointer;
-      touch-action: none;
-    }
-    #${ROOT_ID} .cgpt-nav-scrollbar-thumb {
-      position: absolute;
-      top: 0;
-      left: 3px;
-      width: 7px;
-      min-height: 28px;
-      border-radius: 999px;
-      background: color-mix(in srgb, currentColor 34%, transparent);
-      box-shadow: inset 0 0 0 1px color-mix(in srgb, currentColor 7%, transparent);
-      cursor: grab;
-      transition: background-color 100ms ease;
-    }
-    #${ROOT_ID} .cgpt-nav-scrollbar:hover .cgpt-nav-scrollbar-thumb,
-    #${ROOT_ID} .cgpt-nav-scrollbar-thumb:active {
-      background: color-mix(in srgb, currentColor 55%, transparent);
-    }
-    #${ROOT_ID} .cgpt-nav-scrollbar-thumb:active { cursor: grabbing; }
-    }
-    #${ROOT_ID} .cgpt-nav-panel-item {
-      display: grid;
-      width: 100%;
-      min-height: 34px;
-      grid-template-columns: 28px minmax(0, 1fr);
-      align-items: center;
-      gap: 4px;
-      padding: 5px 9px 5px 5px;
-      border: 0;
-      border-radius: 9px;
-      background: transparent;
-      color: inherit;
-      cursor: pointer;
-      font: inherit;
-      text-align: left;
-    }
-    #${ROOT_ID} .cgpt-nav-panel-item:hover,
-    #${ROOT_ID} .cgpt-nav-panel-item:focus-visible {
-      background: color-mix(in srgb, currentColor 8%, transparent);
-      outline: none;
-    }
-    #${ROOT_ID} .cgpt-nav-panel-item[data-active="true"] {
-      background: color-mix(in srgb, currentColor 10%, transparent);
-    }
-    #${ROOT_ID} .cgpt-nav-panel-index {
-      color: color-mix(in srgb, currentColor 46%, transparent);
-      font-size: 10px;
-      text-align: right;
-    }
-    #${ROOT_ID} .cgpt-nav-panel-text {
-      min-width: 0;
-      overflow: hidden;
-      font-size: 12px;
-      line-height: 1.4;
-      text-overflow: ellipsis;
-      white-space: nowrap;
     }
     @media (prefers-reduced-motion: reduce) {
       #${ROOT_ID} *, #${ROOT_ID} *::before, #${ROOT_ID} *::after { transition: none !important; }
@@ -269,41 +144,9 @@
     tooltip.className = "cgpt-nav-tooltip";
     tooltip.setAttribute("role", "tooltip");
 
-    panel = document.createElement("section");
-    panel.className = "cgpt-nav-panel";
-    panel.setAttribute("aria-label", "全部历史提问");
-
-    const panelHeader = document.createElement("div");
-    panelHeader.className = "cgpt-nav-panel-header";
-    panelCount = document.createElement("span");
-    const panelHint = document.createElement("span");
-    panelHint.className = "cgpt-nav-panel-hint";
-    panelHint.textContent = "滚轮 / 拖动右侧滑块";
-    panelHeader.append(panelCount, panelHint);
-
-    panelList = document.createElement("div");
-    panelList.className = "cgpt-nav-panel-list";
-    panelList.setAttribute("role", "list");
-    panelList.addEventListener("scroll", syncPanelScrollbar, { passive: true });
-    panelList.addEventListener("wheel", handleNavigationWheel, { passive: false });
     list.addEventListener("wheel", handleNavigationWheel, { passive: false });
 
-    const panelBody = document.createElement("div");
-    panelBody.className = "cgpt-nav-panel-body";
-    panelScrollbar = document.createElement("div");
-    panelScrollbar.className = "cgpt-nav-scrollbar";
-    panelScrollbar.setAttribute("role", "scrollbar");
-    panelScrollbar.setAttribute("aria-label", "历史提问位置");
-    panelScrollbar.setAttribute("aria-orientation", "vertical");
-    panelThumb = document.createElement("div");
-    panelThumb.className = "cgpt-nav-scrollbar-thumb";
-    panelScrollbar.appendChild(panelThumb);
-    panelScrollbar.addEventListener("pointerdown", startScrollbarDrag);
-    panelBody.append(panelList, panelScrollbar);
-
-    panel.append(panelHeader, panelBody);
-
-    root.append(list, tooltip, panel);
+    root.append(list, tooltip);
     document.body.appendChild(root);
   }
 
@@ -333,18 +176,64 @@
       }) || null;
   }
 
-  function getUserMessageTargets(conversation) {
+  function getMessageTargets(conversation) {
     const keyedUnits = [...conversation.querySelectorAll("[data-content-search-unit-key]")]
-      .filter((unit) => (unit.getAttribute("data-content-search-unit-key") || "").endsWith(":user"));
-    if (keyedUnits.length) return keyedUnits;
+      .filter((unit) => (unit.getAttribute("data-content-search-unit-key") || "")
+        .endsWith(":user"));
+    const mountedByKey = new Map(keyedUnits.map((unit) => [
+      unit.getAttribute("data-content-search-unit-key"),
+      unit,
+    ]));
+
+    const fiberKey = Object.getOwnPropertyNames(conversation)
+      .find((key) => key.startsWith("__reactFiber$"));
+    let fiber = fiberKey ? conversation[fiberKey] : null;
+    let entries = null;
+    for (let depth = 0; fiber && depth < 30; depth += 1, fiber = fiber.return) {
+      if (Array.isArray(fiber.memoizedProps?.entries)) {
+        entries = fiber.memoizedProps.entries;
+        break;
+      }
+    }
+
+    if (entries?.length) {
+      return entries.flatMap((entry, turnIndex) => {
+        const userItemIndex = (entry.turn?.items || [])
+          .findIndex((item) => item?.type === "user-message");
+        if (userItemIndex < 0) return [];
+        const item = entry.turn.items[userItemIndex];
+        const turnKey = entry.turnKey || entry.id || `fallback-turn-${turnIndex}`;
+        const key = `${turnKey}:${userItemIndex}:user`;
+        return [{
+          key,
+          text: item.message || "（附件或空消息）",
+          target: mountedByKey.get(key) || null,
+          turnIndex,
+        }];
+      });
+    }
+
+    if (keyedUnits.length) {
+      return keyedUnits.map((target, turnIndex) => ({
+        key: target.getAttribute("data-content-search-unit-key") || `mounted-${turnIndex}`,
+        text: "",
+        target,
+        turnIndex,
+      }));
+    }
 
     return [...conversation.querySelectorAll("h4")]
       .filter((heading) => /^(你说：?|You said:?)$/i.test((heading.textContent || "").trim()))
-      .map((heading) => heading.nextElementSibling || heading);
+      .map((heading, turnIndex) => ({
+        key: `heading-${turnIndex}`,
+        text: "",
+        target: heading.nextElementSibling || heading,
+        turnIndex,
+      }));
   }
 
-  function messageText(target) {
-    const raw = (target.innerText || target.textContent || "")
+  function messageText(record) {
+    const raw = (record?.text || record?.target?.innerText || record?.target?.textContent || "")
       .replace(/\s+/g, " ")
       .trim();
     if (!raw) return "（附件或空消息）";
@@ -367,84 +256,51 @@
   }
 
   function hideTooltip() {
+    window.clearTimeout(tooltipHideTimer);
     if (tooltip) tooltip.dataset.open = "false";
+  }
+
+  function previewSelection(index) {
+    const button = list?.children[index];
+    const record = messageTargets[index];
+    if (!button || !record) return;
+    window.clearTimeout(tooltipHideTimer);
+    setTooltip(button, index, messageText(record));
+    tooltipHideTimer = window.setTimeout(hideTooltip, 900);
   }
 
   function handleNavigationWheel(event) {
     event.preventDefault();
     event.stopPropagation();
-    const maxScroll = Math.max(0, panelList.scrollHeight - panelList.clientHeight);
-    if (maxScroll > 1) {
-      panelList.scrollTop += event.deltaY;
-      syncPanelScrollbar();
-      return;
-    }
-
     const now = performance.now();
     if (now - lastWheelStepAt < 130 || Math.abs(event.deltaY) < 2) return;
     lastWheelStepAt = now;
     const direction = event.deltaY > 0 ? 1 : -1;
-    jumpTo(Math.max(0, Math.min(messageTargets.length - 1, activeIndex + direction)));
+    const base = selectedIndex >= 0 ? selectedIndex : activeIndex;
+    setSelectedVisual(
+      Math.max(0, Math.min(messageTargets.length - 1, base + direction)),
+      true
+    );
   }
 
-  function setScrollbarPosition(clientY, grabOffset) {
-    if (!panelScrollbar || !panelThumb || !messageTargets.length) return;
-    const trackRect = panelScrollbar.getBoundingClientRect();
-    const thumbHeight = panelThumb.offsetHeight;
-    const travel = Math.max(1, trackRect.height - thumbHeight);
-    const ratio = Math.max(0, Math.min(1,
-      (clientY - trackRect.top - grabOffset) / travel
-    ));
-    const maxScroll = Math.max(0, panelList.scrollHeight - panelList.clientHeight);
-    if (maxScroll > 1) {
-      panelList.scrollTop = ratio * maxScroll;
-    } else {
-      jumpTo(Math.round(ratio * Math.max(0, messageTargets.length - 1)));
+  function setSelectedVisual(next, showPreview = false) {
+    if (!messageTargets.length) return;
+    selectedIndex = Math.max(0, Math.min(messageTargets.length - 1, next));
+    [...list.children].forEach((button, index) => {
+      button.dataset.selected = String(index === selectedIndex);
+      if (index === selectedIndex) button.setAttribute("aria-selected", "true");
+      else button.removeAttribute("aria-selected");
+    });
+    const selectedButton = list.children[selectedIndex];
+    if (selectedButton) {
+      const top = selectedButton.offsetTop;
+      const bottom = top + selectedButton.offsetHeight;
+      if (top < list.scrollTop) list.scrollTop = Math.max(0, top - 8);
+      else if (bottom > list.scrollTop + list.clientHeight) {
+        list.scrollTop = bottom - list.clientHeight + 8;
+      }
     }
-    syncPanelScrollbar();
-  }
-
-  function startScrollbarDrag(event) {
-    event.preventDefault();
-    event.stopPropagation();
-    const thumbRect = panelThumb.getBoundingClientRect();
-    const grabOffset = event.target === panelThumb
-      ? Math.max(0, Math.min(thumbRect.height, event.clientY - thumbRect.top))
-      : thumbRect.height / 2;
-    setScrollbarPosition(event.clientY, grabOffset);
-
-    const move = (moveEvent) => {
-      moveEvent.preventDefault();
-      setScrollbarPosition(moveEvent.clientY, grabOffset);
-    };
-    const stop = () => {
-      window.removeEventListener("pointermove", move);
-      window.removeEventListener("pointerup", stop);
-      window.removeEventListener("pointercancel", stop);
-    };
-    window.addEventListener("pointermove", move, { passive: false });
-    window.addEventListener("pointerup", stop, { once: true });
-    window.addEventListener("pointercancel", stop, { once: true });
-  }
-
-  function syncPanelScrollbar() {
-    if (!panelScrollbar || !panelThumb || !panelList) return;
-    const trackHeight = panelScrollbar.clientHeight;
-    if (!trackHeight) return;
-    const maxScroll = Math.max(0, panelList.scrollHeight - panelList.clientHeight);
-    const hasOverflow = maxScroll > 1;
-    const thumbHeight = hasOverflow
-      ? Math.max(28, trackHeight * panelList.clientHeight / panelList.scrollHeight)
-      : Math.max(28, Math.min(48, trackHeight * 0.28));
-    const travel = Math.max(0, trackHeight - thumbHeight);
-    const ratio = hasOverflow
-      ? panelList.scrollTop / maxScroll
-      : activeIndex / Math.max(1, messageTargets.length - 1);
-    panelThumb.style.height = `${thumbHeight}px`;
-    panelThumb.style.transform = `translateY(${Math.max(0, Math.min(travel, ratio * travel))}px)`;
-    panelScrollbar.setAttribute("aria-valuemin", "1");
-    panelScrollbar.setAttribute("aria-valuemax", String(Math.max(1, messageTargets.length)));
-    panelScrollbar.setAttribute("aria-valuenow", String(Math.max(1, activeIndex + 1)));
+    if (showPreview) previewSelection(selectedIndex);
   }
 
   function setActiveVisual(next) {
@@ -454,12 +310,6 @@
       if (index === next) button.setAttribute("aria-current", "true");
       else button.removeAttribute("aria-current");
     });
-    [...panelList.children].forEach((button, index) => {
-      button.dataset.active = String(index === next);
-      if (index === next) button.setAttribute("aria-current", "true");
-      else button.removeAttribute("aria-current");
-    });
-
     const activeButton = list.children[next];
     if (activeButton) {
       const top = activeButton.offsetTop;
@@ -469,23 +319,18 @@
         list.scrollTop = bottom - list.clientHeight + 8;
       }
     }
-    const activePanelButton = panelList.children[next];
-    if (activePanelButton) {
-      const top = activePanelButton.offsetTop;
-      const bottom = top + activePanelButton.offsetHeight;
-      if (top < panelList.scrollTop) panelList.scrollTop = Math.max(0, top - 7);
-      else if (bottom > panelList.scrollTop + panelList.clientHeight) {
-        panelList.scrollTop = bottom - panelList.clientHeight + 7;
-      }
-    }
-    syncPanelScrollbar();
   }
 
-  function jumpTo(index) {
-    const target = messageTargets[index];
-    if (!target?.isConnected) return;
-    cancelLatestRestore();
-    setActiveVisual(index);
+  function resolveRecordTarget(record) {
+    if (record?.target?.isConnected) return record.target;
+    if (!record?.key) return null;
+    const escaped = window.CSS?.escape ? CSS.escape(record.key) : record.key.replace(/"/g, '\\"');
+    const target = document.querySelector(`[data-content-search-unit-key="${escaped}"]`);
+    if (target) record.target = target;
+    return target;
+  }
+
+  function centerTarget(target) {
     target.scrollIntoView({
       behavior: "auto",
       block: "center",
@@ -494,15 +339,44 @@
     window.setTimeout(() => updateActive(true), 420);
   }
 
+  function jumpTo(index) {
+    const record = messageTargets[index];
+    if (!record || !scrollContainer) return;
+    cancelLatestRestore();
+    hideTooltip();
+    setSelectedVisual(index);
+    setActiveVisual(index);
+    const mounted = resolveRecordTarget(record);
+    if (mounted) {
+      centerTarget(mounted);
+      return;
+    }
+
+    const maxScroll = Math.max(0, scrollContainer.scrollHeight - scrollContainer.clientHeight);
+    const fromLatest = (messageTargets.length - 1 - index) /
+      Math.max(1, messageTargets.length - 1);
+    scrollContainer.scrollTo({ top: -maxScroll * fromLatest, behavior: "auto" });
+
+    const deadline = performance.now() + 1800;
+    const findTarget = () => {
+      const target = resolveRecordTarget(record);
+      if (target) {
+        centerTarget(target);
+        return;
+      }
+      if (performance.now() < deadline) window.setTimeout(findTarget, 60);
+    };
+    window.setTimeout(findTarget, 40);
+  }
+
   function renderItems(nextBubbles) {
     messageTargets = nextBubbles;
     activeIndex = -1;
+    selectedIndex = -1;
     list.replaceChildren();
-    panelList.replaceChildren();
-    panelCount.textContent = `全部提问 · ${nextBubbles.length}`;
 
-    nextBubbles.forEach((bubble, index) => {
-      const text = messageText(bubble);
+    nextBubbles.forEach((record, index) => {
+      const text = messageText(record);
       const button = document.createElement("button");
       button.type = "button";
       button.className = "cgpt-nav-item";
@@ -516,34 +390,19 @@
       button.addEventListener("mouseleave", hideTooltip);
       button.addEventListener("blur", hideTooltip);
       list.appendChild(button);
-
-      const panelButton = document.createElement("button");
-      panelButton.type = "button";
-      panelButton.className = "cgpt-nav-panel-item";
-      panelButton.dataset.index = String(index);
-      panelButton.setAttribute("role", "listitem");
-      panelButton.setAttribute("aria-label", `跳转到第 ${index + 1} 条提问：${text}`);
-      const number = document.createElement("span");
-      number.className = "cgpt-nav-panel-index";
-      number.textContent = String(index + 1);
-      const label = document.createElement("span");
-      label.className = "cgpt-nav-panel-text";
-      label.textContent = text;
-      panelButton.append(number, label);
-      panelButton.addEventListener("click", () => jumpTo(index));
-      panelList.appendChild(panelButton);
     });
-    requestAnimationFrame(syncPanelScrollbar);
   }
 
   function sameMessages(next) {
     return next.length === messageTargets.length &&
-      next.every((element, index) => element === messageTargets[index]);
+      next.every((record, index) => record.key === messageTargets[index]?.key &&
+        record.text === messageTargets[index]?.text);
   }
 
   function isConversationReplacement(next) {
     if (!messageTargets.length || !next.length) return true;
-    return !next.some((element) => messageTargets.includes(element));
+    const currentKeys = new Set(messageTargets.map((record) => record.key));
+    return !next.some((record) => currentKeys.has(record.key));
   }
 
   function cancelLatestRestore() {
@@ -558,7 +417,7 @@
     if (document.visibilityState === "hidden") return false;
     const conversation = getConversation();
     const currentScroll = getScrollContainer(conversation);
-    const currentTargets = conversation ? getUserMessageTargets(conversation) : [];
+    const currentTargets = conversation ? getMessageTargets(conversation) : [];
     if (!currentScroll || !currentTargets.length) return false;
 
     scrollContainer = currentScroll;
@@ -606,7 +465,9 @@
       let next = 0;
       let best = Number.POSITIVE_INFINITY;
 
-      messageTargets.forEach((target, index) => {
+      messageTargets.forEach((record, index) => {
+        const target = resolveRecordTarget(record);
+        if (!target) return;
         const rect = target.getBoundingClientRect();
         const distance = Math.abs(rect.top - guide);
         if (distance < best) {
@@ -655,8 +516,8 @@
     if (nextConversationKey) conversationKey = nextConversationKey;
     if (conversationKeyChanged || conversationKeyInitialized) scheduleLatestRestore();
     const nextBubbles = conversation
-      ? getUserMessageTargets(conversation)
-          .filter((target) => !target.closest(`#${ROOT_ID}`))
+      ? getMessageTargets(conversation)
+          .filter((record) => !record.target?.closest(`#${ROOT_ID}`))
       : [];
 
     if (!nextScroll || !nextBubbles.length) {
@@ -676,8 +537,10 @@
     const conversationReplaced = conversationKeyChanged ||
       (messagesChanged && isConversationReplacement(nextBubbles));
     if (messagesChanged) {
+      hideTooltip();
       renderItems(nextBubbles);
       setActiveVisual(nextBubbles.length - 1);
+      setSelectedVisual(nextBubbles.length - 1);
       if (conversationReplaced) scheduleLatestRestore();
     }
 
@@ -718,7 +581,7 @@
     document.removeEventListener("visibilitychange", handleVisibilityChange);
     root?.remove();
     style.remove();
-    root = list = tooltip = panel = panelList = panelCount = panelScrollbar = panelThumb = null;
+    root = list = tooltip = null;
     messageTargets = [];
     delete window[INSTALL_KEY];
     delete window[API_KEY];

--- a/scripts/chatgpt-message-navigator.js
+++ b/scripts/chatgpt-message-navigator.js
@@ -5,7 +5,7 @@
   const API_KEY = "__chatgptMessageNavigator";
   const ROOT_ID = "chatgpt-message-navigator";
   const STYLE_ID = "chatgpt-message-navigator-style";
-  const VERSION = "1.1.1";
+  const VERSION = "1.1.4";
 
   if (window[API_KEY]?.destroy) window[API_KEY].destroy();
 
@@ -18,10 +18,14 @@
   let panelScrollbar = null;
   let panelThumb = null;
   let lastWheelStepAt = 0;
+  let conversationKey = "";
   let scrollContainer = null;
   let messageTargets = [];
   let activeIndex = -1;
   let updateTimer = 0;
+  let restoreLatestTimer = 0;
+  let restoreLatestInterval = 0;
+  let pendingLatestRestore = false;
   let frame = 0;
 
   const style = document.createElement("style");
@@ -307,6 +311,17 @@
     return document.querySelector('[data-thread-find-target="conversation"]');
   }
 
+  function getConversationKey() {
+    const titleButton = [...document.querySelectorAll("button")].find((button) => {
+      const rect = button.getBoundingClientRect();
+      const text = (button.innerText || "").trim();
+      return rect.left > 275 && rect.top >= 18 && rect.top < 83 &&
+        rect.width > 50 && text && text.length < 160 &&
+        !button.getAttribute("aria-label");
+    });
+    return (titleButton?.innerText || "").trim();
+  }
+
   function getScrollContainer(conversation) {
     return conversation?.closest(".thread-scroll-container") ||
       conversation?.parentElement?.closest(".thread-scroll-container") ||
@@ -469,6 +484,7 @@
   function jumpTo(index) {
     const target = messageTargets[index];
     if (!target?.isConnected) return;
+    cancelLatestRestore();
     setActiveVisual(index);
     target.scrollIntoView({
       behavior: "auto",
@@ -525,6 +541,52 @@
       next.every((element, index) => element === messageTargets[index]);
   }
 
+  function isConversationReplacement(next) {
+    if (!messageTargets.length || !next.length) return true;
+    return !next.some((element) => messageTargets.includes(element));
+  }
+
+  function cancelLatestRestore() {
+    clearTimeout(restoreLatestTimer);
+    clearInterval(restoreLatestInterval);
+    restoreLatestTimer = 0;
+    restoreLatestInterval = 0;
+    pendingLatestRestore = false;
+  }
+
+  function guardLatestPosition() {
+    if (document.visibilityState === "hidden") return false;
+    const conversation = getConversation();
+    const currentScroll = getScrollContainer(conversation);
+    const currentTargets = conversation ? getUserMessageTargets(conversation) : [];
+    if (!currentScroll || !currentTargets.length) return false;
+
+    scrollContainer = currentScroll;
+    setActiveVisual(currentTargets.length - 1);
+    if (Math.abs(currentScroll.scrollTop) > 1) {
+      currentScroll.scrollTo({ top: 0, behavior: "auto" });
+    }
+    return true;
+  }
+
+  function scheduleLatestRestore(delay = 140) {
+    cancelLatestRestore();
+    pendingLatestRestore = true;
+    restoreLatestTimer = window.setTimeout(() => {
+      const deadline = performance.now() + 15000;
+      const tick = () => {
+        guardLatestPosition();
+        if (performance.now() < deadline || document.visibilityState === "hidden") return;
+        clearInterval(restoreLatestInterval);
+        restoreLatestInterval = 0;
+        pendingLatestRestore = false;
+        updateActive(true);
+      };
+      tick();
+      restoreLatestInterval = window.setInterval(tick, 120);
+    }, delay);
+  }
+
   function positionRoot() {
     if (!root || root.hidden || !scrollContainer) return;
     const rect = scrollContainer.getBoundingClientRect();
@@ -536,8 +598,10 @@
   function updateActive(force = false) {
     cancelAnimationFrame(frame);
     frame = requestAnimationFrame(() => {
-      if (root?.hidden || !scrollContainer || !messageTargets.length) return;
+      if (root?.hidden || !scrollContainer || !messageTargets.length ||
+          document.visibilityState === "hidden" || pendingLatestRestore) return;
       const viewport = scrollContainer.getBoundingClientRect();
+      if (viewport.height < 100 || viewport.width < 100) return;
       const guide = viewport.top + Math.min(viewport.height * 0.38, 360);
       let next = 0;
       let best = Number.POSITIVE_INFINITY;
@@ -558,7 +622,14 @@
 
   function detachScroll() {
     scrollContainer?.removeEventListener("scroll", updateActive);
+    scrollContainer?.removeEventListener("wheel", handleConversationUserIntent);
+    scrollContainer?.removeEventListener("pointerdown", handleConversationUserIntent);
+    scrollContainer?.removeEventListener("touchstart", handleConversationUserIntent);
     scrollContainer = null;
+  }
+
+  function handleConversationUserIntent() {
+    if (pendingLatestRestore) cancelLatestRestore();
   }
 
   function refresh() {
@@ -568,11 +639,21 @@
       hideTooltip();
       detachScroll();
       messageTargets = [];
+      conversationKey = "";
       return;
     }
 
+    if (document.visibilityState === "hidden") return;
+
     const conversation = getConversation();
     const nextScroll = getScrollContainer(conversation);
+    const nextConversationKey = getConversationKey();
+    const conversationKeyChanged = Boolean(
+      nextConversationKey && conversationKey && nextConversationKey !== conversationKey
+    );
+    const conversationKeyInitialized = Boolean(nextConversationKey && !conversationKey);
+    if (nextConversationKey) conversationKey = nextConversationKey;
+    if (conversationKeyChanged || conversationKeyInitialized) scheduleLatestRestore();
     const nextBubbles = conversation
       ? getUserMessageTargets(conversation)
           .filter((target) => !target.closest(`#${ROOT_ID}`))
@@ -587,12 +668,22 @@
       detachScroll();
       scrollContainer = nextScroll;
       scrollContainer.addEventListener("scroll", updateActive, { passive: true });
+      scrollContainer.addEventListener("wheel", handleConversationUserIntent, { passive: true });
+      scrollContainer.addEventListener("pointerdown", handleConversationUserIntent, { passive: true });
+      scrollContainer.addEventListener("touchstart", handleConversationUserIntent, { passive: true });
     }
-    if (!sameMessages(nextBubbles)) renderItems(nextBubbles);
+    const messagesChanged = !sameMessages(nextBubbles);
+    const conversationReplaced = conversationKeyChanged ||
+      (messagesChanged && isConversationReplacement(nextBubbles));
+    if (messagesChanged) {
+      renderItems(nextBubbles);
+      setActiveVisual(nextBubbles.length - 1);
+      if (conversationReplaced) scheduleLatestRestore();
+    }
 
     root.hidden = false;
     positionRoot();
-    updateActive(true);
+    if (!pendingLatestRestore) updateActive(true);
   }
 
   function scheduleRefresh(delay = 120) {
@@ -608,14 +699,23 @@
 
   const interval = window.setInterval(() => scheduleRefresh(0), 1200);
   window.addEventListener("resize", positionRoot);
+  const handleVisibilityChange = () => {
+    if (document.visibilityState === "visible") {
+      if (pendingLatestRestore) scheduleLatestRestore(180);
+      else scheduleRefresh(180);
+    }
+  };
+  document.addEventListener("visibilitychange", handleVisibilityChange);
 
   function destroy() {
     clearTimeout(updateTimer);
+    cancelLatestRestore();
     clearInterval(interval);
     cancelAnimationFrame(frame);
     observer.disconnect();
     detachScroll();
     window.removeEventListener("resize", positionRoot);
+    document.removeEventListener("visibilitychange", handleVisibilityChange);
     root?.remove();
     style.remove();
     root = list = tooltip = panel = panelList = panelCount = panelScrollbar = panelThumb = null;

--- a/scripts/chatgpt-message-navigator.js
+++ b/scripts/chatgpt-message-navigator.js
@@ -5,7 +5,7 @@
   const API_KEY = "__chatgptMessageNavigator";
   const ROOT_ID = "chatgpt-message-navigator";
   const STYLE_ID = "chatgpt-message-navigator-style";
-  const VERSION = "1.1.0";
+  const VERSION = "1.1.1";
 
   if (window[API_KEY]?.destroy) window[API_KEY].destroy();
 
@@ -15,6 +15,9 @@
   let panel = null;
   let panelList = null;
   let panelCount = null;
+  let panelScrollbar = null;
+  let panelThumb = null;
+  let lastWheelStepAt = 0;
   let scrollContainer = null;
   let messageTargets = [];
   let activeIndex = -1;
@@ -158,17 +161,40 @@
       overflow-y: auto;
       overscroll-behavior: contain;
       padding: 7px;
-      scrollbar-gutter: stable;
-      scrollbar-width: thin;
-      scrollbar-color: color-mix(in srgb, currentColor 27%, transparent) transparent;
+      scrollbar-width: none;
     }
-    #${ROOT_ID} .cgpt-nav-panel-list::-webkit-scrollbar { width: 10px; }
-    #${ROOT_ID} .cgpt-nav-panel-list::-webkit-scrollbar-track { background: transparent; }
-    #${ROOT_ID} .cgpt-nav-panel-list::-webkit-scrollbar-thumb {
-      border: 3px solid transparent;
+    #${ROOT_ID} .cgpt-nav-panel-list::-webkit-scrollbar { display: none; }
+    #${ROOT_ID} .cgpt-nav-panel-body {
+      display: grid;
+      min-height: 0;
+      grid-template-columns: minmax(0, 1fr) 16px;
+    }
+    #${ROOT_ID} .cgpt-nav-scrollbar {
+      position: relative;
+      min-height: 48px;
+      margin: 8px 4px 8px 0;
       border-radius: 999px;
-      background: color-mix(in srgb, currentColor 28%, transparent);
-      background-clip: padding-box;
+      background: color-mix(in srgb, currentColor 8%, transparent);
+      cursor: pointer;
+      touch-action: none;
+    }
+    #${ROOT_ID} .cgpt-nav-scrollbar-thumb {
+      position: absolute;
+      top: 0;
+      left: 3px;
+      width: 7px;
+      min-height: 28px;
+      border-radius: 999px;
+      background: color-mix(in srgb, currentColor 34%, transparent);
+      box-shadow: inset 0 0 0 1px color-mix(in srgb, currentColor 7%, transparent);
+      cursor: grab;
+      transition: background-color 100ms ease;
+    }
+    #${ROOT_ID} .cgpt-nav-scrollbar:hover .cgpt-nav-scrollbar-thumb,
+    #${ROOT_ID} .cgpt-nav-scrollbar-thumb:active {
+      background: color-mix(in srgb, currentColor 55%, transparent);
+    }
+    #${ROOT_ID} .cgpt-nav-scrollbar-thumb:active { cursor: grabbing; }
     }
     #${ROOT_ID} .cgpt-nav-panel-item {
       display: grid;
@@ -248,20 +274,30 @@
     panelCount = document.createElement("span");
     const panelHint = document.createElement("span");
     panelHint.className = "cgpt-nav-panel-hint";
-    panelHint.textContent = "滚轮或拖动滚动条";
+    panelHint.textContent = "滚轮 / 拖动右侧滑块";
     panelHeader.append(panelCount, panelHint);
 
     panelList = document.createElement("div");
     panelList.className = "cgpt-nav-panel-list";
     panelList.setAttribute("role", "list");
-    panelList.addEventListener("wheel", (event) => event.stopPropagation(), { passive: true });
-    list.addEventListener("wheel", (event) => {
-      if (panelList.scrollHeight <= panelList.clientHeight) return;
-      event.preventDefault();
-      panelList.scrollTop += event.deltaY;
-    }, { passive: false });
+    panelList.addEventListener("scroll", syncPanelScrollbar, { passive: true });
+    panelList.addEventListener("wheel", handleNavigationWheel, { passive: false });
+    list.addEventListener("wheel", handleNavigationWheel, { passive: false });
 
-    panel.append(panelHeader, panelList);
+    const panelBody = document.createElement("div");
+    panelBody.className = "cgpt-nav-panel-body";
+    panelScrollbar = document.createElement("div");
+    panelScrollbar.className = "cgpt-nav-scrollbar";
+    panelScrollbar.setAttribute("role", "scrollbar");
+    panelScrollbar.setAttribute("aria-label", "历史提问位置");
+    panelScrollbar.setAttribute("aria-orientation", "vertical");
+    panelThumb = document.createElement("div");
+    panelThumb.className = "cgpt-nav-scrollbar-thumb";
+    panelScrollbar.appendChild(panelThumb);
+    panelScrollbar.addEventListener("pointerdown", startScrollbarDrag);
+    panelBody.append(panelList, panelScrollbar);
+
+    panel.append(panelHeader, panelBody);
 
     root.append(list, tooltip, panel);
     document.body.appendChild(root);
@@ -319,15 +355,127 @@
     if (tooltip) tooltip.dataset.open = "false";
   }
 
+  function handleNavigationWheel(event) {
+    event.preventDefault();
+    event.stopPropagation();
+    const maxScroll = Math.max(0, panelList.scrollHeight - panelList.clientHeight);
+    if (maxScroll > 1) {
+      panelList.scrollTop += event.deltaY;
+      syncPanelScrollbar();
+      return;
+    }
+
+    const now = performance.now();
+    if (now - lastWheelStepAt < 130 || Math.abs(event.deltaY) < 2) return;
+    lastWheelStepAt = now;
+    const direction = event.deltaY > 0 ? 1 : -1;
+    jumpTo(Math.max(0, Math.min(messageTargets.length - 1, activeIndex + direction)));
+  }
+
+  function setScrollbarPosition(clientY, grabOffset) {
+    if (!panelScrollbar || !panelThumb || !messageTargets.length) return;
+    const trackRect = panelScrollbar.getBoundingClientRect();
+    const thumbHeight = panelThumb.offsetHeight;
+    const travel = Math.max(1, trackRect.height - thumbHeight);
+    const ratio = Math.max(0, Math.min(1,
+      (clientY - trackRect.top - grabOffset) / travel
+    ));
+    const maxScroll = Math.max(0, panelList.scrollHeight - panelList.clientHeight);
+    if (maxScroll > 1) {
+      panelList.scrollTop = ratio * maxScroll;
+    } else {
+      jumpTo(Math.round(ratio * Math.max(0, messageTargets.length - 1)));
+    }
+    syncPanelScrollbar();
+  }
+
+  function startScrollbarDrag(event) {
+    event.preventDefault();
+    event.stopPropagation();
+    const thumbRect = panelThumb.getBoundingClientRect();
+    const grabOffset = event.target === panelThumb
+      ? Math.max(0, Math.min(thumbRect.height, event.clientY - thumbRect.top))
+      : thumbRect.height / 2;
+    setScrollbarPosition(event.clientY, grabOffset);
+
+    const move = (moveEvent) => {
+      moveEvent.preventDefault();
+      setScrollbarPosition(moveEvent.clientY, grabOffset);
+    };
+    const stop = () => {
+      window.removeEventListener("pointermove", move);
+      window.removeEventListener("pointerup", stop);
+      window.removeEventListener("pointercancel", stop);
+    };
+    window.addEventListener("pointermove", move, { passive: false });
+    window.addEventListener("pointerup", stop, { once: true });
+    window.addEventListener("pointercancel", stop, { once: true });
+  }
+
+  function syncPanelScrollbar() {
+    if (!panelScrollbar || !panelThumb || !panelList) return;
+    const trackHeight = panelScrollbar.clientHeight;
+    if (!trackHeight) return;
+    const maxScroll = Math.max(0, panelList.scrollHeight - panelList.clientHeight);
+    const hasOverflow = maxScroll > 1;
+    const thumbHeight = hasOverflow
+      ? Math.max(28, trackHeight * panelList.clientHeight / panelList.scrollHeight)
+      : Math.max(28, Math.min(48, trackHeight * 0.28));
+    const travel = Math.max(0, trackHeight - thumbHeight);
+    const ratio = hasOverflow
+      ? panelList.scrollTop / maxScroll
+      : activeIndex / Math.max(1, messageTargets.length - 1);
+    panelThumb.style.height = `${thumbHeight}px`;
+    panelThumb.style.transform = `translateY(${Math.max(0, Math.min(travel, ratio * travel))}px)`;
+    panelScrollbar.setAttribute("aria-valuemin", "1");
+    panelScrollbar.setAttribute("aria-valuemax", String(Math.max(1, messageTargets.length)));
+    panelScrollbar.setAttribute("aria-valuenow", String(Math.max(1, activeIndex + 1)));
+  }
+
+  function setActiveVisual(next) {
+    activeIndex = next;
+    [...list.children].forEach((button, index) => {
+      button.dataset.active = String(index === next);
+      if (index === next) button.setAttribute("aria-current", "true");
+      else button.removeAttribute("aria-current");
+    });
+    [...panelList.children].forEach((button, index) => {
+      button.dataset.active = String(index === next);
+      if (index === next) button.setAttribute("aria-current", "true");
+      else button.removeAttribute("aria-current");
+    });
+
+    const activeButton = list.children[next];
+    if (activeButton) {
+      const top = activeButton.offsetTop;
+      const bottom = top + activeButton.offsetHeight;
+      if (top < list.scrollTop) list.scrollTop = Math.max(0, top - 8);
+      else if (bottom > list.scrollTop + list.clientHeight) {
+        list.scrollTop = bottom - list.clientHeight + 8;
+      }
+    }
+    const activePanelButton = panelList.children[next];
+    if (activePanelButton) {
+      const top = activePanelButton.offsetTop;
+      const bottom = top + activePanelButton.offsetHeight;
+      if (top < panelList.scrollTop) panelList.scrollTop = Math.max(0, top - 7);
+      else if (bottom > panelList.scrollTop + panelList.clientHeight) {
+        panelList.scrollTop = bottom - panelList.clientHeight + 7;
+      }
+    }
+    syncPanelScrollbar();
+  }
+
   function jumpTo(index) {
     const target = messageTargets[index];
     if (!target?.isConnected) return;
+    setActiveVisual(index);
     target.scrollIntoView({
       behavior: "auto",
       block: "center",
       inline: "nearest",
     });
-    window.setTimeout(() => updateActive(true), 180);
+    window.setTimeout(() => updateActive(true), 420);
   }
 
   function renderItems(nextBubbles) {
@@ -369,6 +517,7 @@
       panelButton.addEventListener("click", () => jumpTo(index));
       panelList.appendChild(panelButton);
     });
+    requestAnimationFrame(syncPanelScrollbar);
   }
 
   function sameMessages(next) {
@@ -403,36 +552,7 @@
       });
 
       if (!force && next === activeIndex) return;
-      activeIndex = next;
-      [...list.children].forEach((button, index) => {
-        button.dataset.active = String(index === next);
-        if (index === next) button.setAttribute("aria-current", "true");
-        else button.removeAttribute("aria-current");
-      });
-      [...panelList.children].forEach((button, index) => {
-        button.dataset.active = String(index === next);
-        if (index === next) button.setAttribute("aria-current", "true");
-        else button.removeAttribute("aria-current");
-      });
-
-      const activeButton = list.children[next];
-      if (activeButton) {
-        const top = activeButton.offsetTop;
-        const bottom = top + activeButton.offsetHeight;
-        if (top < list.scrollTop) list.scrollTop = Math.max(0, top - 8);
-        else if (bottom > list.scrollTop + list.clientHeight) {
-          list.scrollTop = bottom - list.clientHeight + 8;
-        }
-      }
-      const activePanelButton = panelList.children[next];
-      if (activePanelButton) {
-        const top = activePanelButton.offsetTop;
-        const bottom = top + activePanelButton.offsetHeight;
-        if (top < panelList.scrollTop) panelList.scrollTop = Math.max(0, top - 7);
-        else if (bottom > panelList.scrollTop + panelList.clientHeight) {
-          panelList.scrollTop = bottom - panelList.clientHeight + 7;
-        }
-      }
+      setActiveVisual(next);
     });
   }
 
@@ -498,7 +618,7 @@
     window.removeEventListener("resize", positionRoot);
     root?.remove();
     style.remove();
-    root = list = tooltip = panel = panelList = panelCount = null;
+    root = list = tooltip = panel = panelList = panelCount = panelScrollbar = panelThumb = null;
     messageTargets = [];
     delete window[INSTALL_KEY];
     delete window[API_KEY];


### PR DESCRIPTION
## 概要

更新 **ChatGPT Message Navigator 1.1.11**，为 Codex Desktop 的 ChatGPT 模式提供类似 Codex 的长对话用户提问导航。

## 功能

- 从 ChatGPT 内部对话数据读取全部用户提问，包括尚未渲染的较早消息
- 只显示用户提问，不包含 GPT 回答
- 点击短线跳转；较早消息会先加载再精确定位
- 悬停短线临时显示提问摘要，移开后隐藏
- 在导航条上滚动仅切换预览选中项，不滚动或跳转聊天正文
- 不显示额外历史面板或自定义滚动条
- 新消息会更新导航，但不会自动弹出预览框
- 修复切换聊天后回弹到最早历史的问题
- 仅在 ChatGPT 模式启用，不干扰 Codex 原生导航
- 不修改聊天记录或创建对话分支

## 验证

- Codex Desktop: 26.814.5167
- Codex++: 1.2.47
- Windows
- JavaScript syntax check passed
- 市场 SHA-256 与提交脚本一致

项目主页：https://github.com/Takizzl/chatgpt-message-navigator

## 演示

<p align="center">\n  <img src="https://raw.githubusercontent.com/Takizzl/chatgpt-message-navigator/efd75e6/assets/demo.png" alt="ChatGPT Message Navigator 演示" width="50%">\n</p>